### PR TITLE
#5 API共通仕様設計書追加 既存APIを整合性がとれるように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ TODO:
 ## ディレクトリ構成
 ### 詳細
 アーキテクチャ詳細は[こちら](./docs/architecture.md)を参照してください。
+HTTP API 設計ルールは[こちら](./docs/api_design.md)を参照してください。
 
 ## 開発・品質
 - テスト: `task test`（`go test -race -cover` + `coverage.html` 出力、`t.Parallel()` で並列安全性検証）

--- a/docs/api_design.md
+++ b/docs/api_design.md
@@ -1,0 +1,210 @@
+# API 共通仕様 設計
+
+## 目的
+
+本ドキュメントは、このリポジトリで提供する HTTP API の設計方針を統一するためのルールを定義する。
+
+- 実装・レビュー・保守の判断基準を明確にする
+- 本設計書ではコーディング規約とアーキテクチャはスコープ外とする
+- `internal/app/presentation` と `internal/app/middleware` における HTTP 境界の責務を揃える
+
+## 適用範囲
+
+- 対象:
+  - `internal/app/presentation/**`
+  - `internal/app/middleware/**`
+  - `internal/app/router/**`
+- 非対象:
+  - Gmail / OpenAI などの外部 API クライアント仕様
+  - 非同期メッセージング内部のインターフェース
+
+## 基本方針
+
+- HTTP API は外部契約であり、内部の domain / application / infrastructure の都合をそのまま露出しない
+- Controller は「入力の受け取り」「アプリケーション層 DTO への変換」「HTTP ステータスとレスポンスへのマッピング」に責務を限定する
+
+## 1. エンドポイント設計
+
+### 1.1 パス設計
+
+- ルートは責務単位でグルーピングする
+  - 例: `/api/v1/auth`, `/api/v1/emails`, `/api/v1/billings`
+- パスセグメントは lower-case ASCII を使う
+- 複数語のセグメントが必要な場合のみ kebab-case を使う
+- 末尾スラッシュは付けない
+
+### 1.2 リソース指向を優先する
+
+- 基本は名詞で設計する
+  - コレクション: `/api/v1/emails`
+  - 単体: `/api/v1/emails/:email_id`
+- 動詞ベースのアクションは、リソースに自然に落とし込めない場合に限定する
+  - 許容例: `/api/v1/auth/login`, `/api/v1/auth/logout`, `/api/v1/auth/register`
+- サブリソースで意図が明確になる場合は、ネストで表現する
+  - 例: `/api/v1/auth/email/verify`, `/api/v1/auth/email/resend`
+
+### 1.3 HTTP メソッドの意味
+
+- `GET`
+  - 取得系
+- `POST`
+  - データ作成、無効化、解除
+  - サーバー主導の副作用を持つアクション
+- `PUT`
+  - 全置換
+- `PATCH`
+  - 部分更新
+- `DELETE`
+  - 削除
+
+注意:
+認証メールの正規入口は frontend の `/signup/verify` とする。backend では `POST /api/v1/auth/email/verify` のみが状態変更の本体であり、メール本文には frontend の URL を記載する。
+
+### 1.4 Path / Query / Body の使い分け
+
+- Path parameter:
+  - リソース識別子
+- Query parameter:
+  - 検索条件
+  - ソート
+  - ページング
+- JSON body:
+  - `POST` / `PUT` / `PATCH` の入力
+  - `POST /api/v1/auth/email/verify` のような状態変更アクションの入力
+- 機微情報は原則 body または header で受け取り、Query には載せない
+  - frontend の画面遷移用に query で token を扱う場合でも、backend API への送信は body へ詰め替える
+
+### 1.5 バージョニング
+
+- 現時点の API は `/api/v1/...` を正規契約とする
+- 破壊的変更が避けられない段階で、パス先頭のバージョンを更新する
+  - 例: `/api/v2/...`
+- 一時的な unversioned compatibility endpoint を残す場合でも、現行契約としては扱わない
+- payload 内に `version` フィールドを混在させて分岐しない
+
+## 2. リクエスト設計
+
+### 2.1 DTO 定義
+
+- HTTP の request / response DTO は feature 配下の controller ファイルに置く
+- JSON の shape が domain DTO と完全一致しない限り、HTTP 専用 DTO を定義する
+- JSON フィールド名は `lower_snake_case` に統一する
+
+### 2.2 バリデーション
+
+- JSON リクエストは `ShouldBindJSON` を使う
+- 必須項目、メール形式などの構文バリデーションは `binding` タグで明示する
+- Controller は構文バリデーションを担当し、業務ルールの検証は application 層へ委譲する
+
+## 3. 成功レスポンス設計
+
+### 3.1 基本ルール
+
+- 成功時は endpoint ごとの目的に沿った JSON を返す
+- 汎用的な レスポンスフォーマットは導入しない
+- リソース返却か、アクション結果返却かが分かる最小構造にする
+
+### 3.2 ステータスコード
+
+| ステータス | 用途 |
+| --- | --- |
+| `200 OK` | 取得成功、または結果本文を返すアクション成功 |
+| `201 Created` | 新規作成成功 |
+| `204 No Content` | 本文不要な成功。Cookie / Header のみ返す操作を含む |
+
+### 3.3 レスポンス形
+
+- 単一リソース:
+  - 例: `{"id":1,"email":"user@example.com"}`
+- アクション結果:
+  - 例: `{"message":"確認メールを再送信しました。"}`
+- 複合結果:
+  - 例: `{"message":"登録が完了しました。","user":{...}}`
+- コレクション:
+  - `items` を基本キーとし、必要に応じて `next_cursor`, `total_count` を追加する
+- `204 No Content` のときは空ボディにする
+- 日時は Go 標準の RFC3339 形式を前提とする
+- 値が存在しない日時や任意項目は `null` を許容する
+
+## 4. エラーレスポンス設計
+
+### 4.1 標準形式
+
+エラーは次の形に統一する。
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "入力値が不正です。"
+  }
+}
+```
+
+バリデーションの詳細が必要な場合のみ `details` を追加してよい。
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "入力値が不正です。",
+    "details": [
+      {
+        "field": "email",
+        "reason": "required"
+      }
+    ]
+  }
+}
+```
+
+### 4.2 各フィールドのルール
+
+- `error.code`
+  - クライアント向けの安定した機械可読コード
+  - `snake_case` を使う
+  - Go の error 文字列をそのまま返さない
+- `error.message`
+  - 画面表示しても問題ない利用者向け文言
+  - 既定値は日本語
+  - 内部実装、SQL、外部 API の生エラーを含めない
+- `error.details`
+  - 任意
+  - 入力項目単位の補足が必要な場合のみ返す
+
+### 4.3 返却方針
+
+- `4xx` は、クライアントが修正可能な失敗理由を返す
+- `5xx` は、原因を秘匿した一般化メッセージを返す
+- `4xx` で空ボディを返さない
+- middleware も controller と同じエラー形式に揃える
+
+### 4.4 ステータスと意味
+
+| ステータス | 用途 |
+| --- | --- |
+| `400 Bad Request` | JSON 不正、必須不足、クエリ不足、業務前提を満たさない入力 |
+| `401 Unauthorized` | 認証情報なし、または無効 |
+| `403 Forbidden` | 認証済みだが実行権限または状態条件を満たさない |
+| `404 Not Found` | 対象リソースなし |
+| `409 Conflict` | 一意制約や同時更新衝突など、競合として区別する価値がある場合 |
+| `429 Too Many Requests` | レート制限超過 |
+| `500 Internal Server Error` | 想定外エラー |
+| `503 Service Unavailable` | 一時的な外部依存障害で、再試行判断を促したい場合 |
+
+認証系の代表例:
+- `email_already_exists` は `409 Conflict`
+- `already_verified` は `403 Forbidden`
+- `token_expired` と `token_already_used` は `409 Conflict`
+- `mail_send_failed` は `503 Service Unavailable`
+
+## 5. テストルール
+
+- Controller / Middleware テストでは最低限次を検証する
+  - 正常系のステータスと本文
+  - 構文バリデーション失敗時のステータスとエラー形式
+  - 代表的な業務エラーのマッピング
+  - Cookie / Header の契約
+  - 認証失敗時のステータスとエラー形式
+- `204 No Content` を返す API は、本文が空であることもテストする
+- API 契約を変える変更では、成功ケースだけでなく失敗ケースのテストも更新する

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,10 @@
     - DI コンテナ: go.uber.org/dig
   </context>
 
+  <related_documents>
+    - HTTP API の詳細ルールは [こちら](./api_design.md) を参照してください
+  </related_documents>
+
   <directory_structure>
     <root_packages>
       - cmd/

--- a/internal/app/httpresponse/error_response.go
+++ b/internal/app/httpresponse/error_response.go
@@ -1,0 +1,75 @@
+package httpresponse
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ErrorResponse is the standard error envelope for HTTP APIs.
+type ErrorResponse struct {
+	Error ErrorDetail `json:"error"`
+}
+
+// ErrorDetail describes a machine-readable and user-facing HTTP error.
+type ErrorDetail struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+const (
+	CodeInvalidRequest       = "invalid_request"
+	CodeInternalServerError  = "internal_server_error"
+	MessageInvalidRequest    = "入力値が不正です。"
+	MessageInternalServerErr = "サーバー内部でエラーが発生しました。しばらくしてから再度お試しください。"
+)
+
+// WriteError writes the standard error envelope without aborting the handler chain.
+func WriteError(c *gin.Context, status int, code, message string) {
+	c.JSON(status, ErrorResponse{
+		Error: ErrorDetail{
+			Code:    code,
+			Message: message,
+		},
+	})
+}
+
+// AbortError aborts the handler chain with the standard error envelope.
+func AbortError(c *gin.Context, status int, code, message string) {
+	c.AbortWithStatusJSON(status, ErrorResponse{
+		Error: ErrorDetail{
+			Code:    code,
+			Message: message,
+		},
+	})
+}
+
+// WriteInvalidRequest writes the standard invalid request response.
+func WriteInvalidRequest(c *gin.Context) {
+	WriteError(c, http.StatusBadRequest, CodeInvalidRequest, MessageInvalidRequest)
+}
+
+// WriteInternalServerError writes the standard internal server error response.
+func WriteInternalServerError(c *gin.Context) {
+	WriteError(c, http.StatusInternalServerError, CodeInternalServerError, MessageInternalServerErr)
+}
+
+// WriteServiceUnavailable writes a 503 response using the standard error envelope.
+func WriteServiceUnavailable(c *gin.Context, code, message string) {
+	WriteError(c, http.StatusServiceUnavailable, code, message)
+}
+
+// AbortUnauthorized aborts with a 401 response using the standard error envelope.
+func AbortUnauthorized(c *gin.Context, code, message string) {
+	AbortError(c, http.StatusUnauthorized, code, message)
+}
+
+// AbortForbidden aborts with a 403 response using the standard error envelope.
+func AbortForbidden(c *gin.Context, code, message string) {
+	AbortError(c, http.StatusForbidden, code, message)
+}
+
+// AbortInternalServerError aborts with the standard internal server error response.
+func AbortInternalServerError(c *gin.Context) {
+	AbortError(c, http.StatusInternalServerError, CodeInternalServerError, MessageInternalServerErr)
+}

--- a/internal/app/middleware/auth_middleware.go
+++ b/internal/app/middleware/auth_middleware.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"business/internal/app/httpresponse"
 	"business/internal/auth/domain"
 	"business/internal/library/logger"
 	"business/internal/library/oswrapper"
@@ -49,8 +50,7 @@ func (m *AuthMiddleware) Authenticate() gin.HandlerFunc {
 		cookieToken, err := c.Cookie("access_token")
 		if err != nil || strings.TrimSpace(cookieToken) == "" {
 			reqLog.Info("permission_denied", permissionDeniedFields(c, "missing_token")...)
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "missing token"})
-			c.Abort()
+			httpresponse.AbortUnauthorized(c, errorCodeMissingToken, errorMessageMissingToken)
 			return
 		}
 
@@ -59,8 +59,7 @@ func (m *AuthMiddleware) Authenticate() gin.HandlerFunc {
 		jwtSecret, err := m.osw.GetEnv("JWT_SECRET_KEY")
 		if err != nil {
 			reqLog.Error("failed to load jwt secret", logger.Err(err))
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
-			c.Abort()
+			httpresponse.AbortInternalServerError(c)
 			return
 		}
 
@@ -72,16 +71,14 @@ func (m *AuthMiddleware) Authenticate() gin.HandlerFunc {
 		})
 		if err != nil || !token.Valid {
 			reqLog.Info("permission_denied", permissionDeniedFields(c, "invalid_token")...)
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
-			c.Abort()
+			httpresponse.AbortUnauthorized(c, errorCodeInvalidToken, errorMessageInvalidToken)
 			return
 		}
 
 		claims, ok := token.Claims.(*domain.AuthClaims)
 		if !ok {
 			reqLog.Info("permission_denied", permissionDeniedFields(c, "invalid_token_claims")...)
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid token claims"})
-			c.Abort()
+			httpresponse.AbortUnauthorized(c, errorCodeInvalidTokenClaims, errorMessageInvalidTokenClaims)
 			return
 		}
 
@@ -89,8 +86,7 @@ func (m *AuthMiddleware) Authenticate() gin.HandlerFunc {
 		requestCtx, err := logger.ContextWithUserID(c.Request.Context(), claims.UserID)
 		if err != nil {
 			reqLog.Error("failed to attach user context", logger.Err(err))
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
-			c.Abort()
+			httpresponse.AbortInternalServerError(c)
 			return
 		}
 
@@ -105,21 +101,14 @@ func (m *AuthMiddleware) Authenticate() gin.HandlerFunc {
 			user, err := m.users.GetUserByID(c.Request.Context(), claims.UserID)
 			if err != nil {
 				reqLog.Info("permission_denied", permissionDeniedFields(c, "user_not_found")...)
-				c.JSON(http.StatusUnauthorized, gin.H{"error": "user not found"})
-				c.Abort()
+				httpresponse.AbortUnauthorized(c, errorCodeUserNotFound, errorMessageUserNotFound)
 				return
 			}
 
 			// Check if email is verified
 			if !user.IsEmailVerified() {
 				reqLog.Info("permission_denied", permissionDeniedFields(c, "email_verification_required")...)
-				c.JSON(http.StatusUnauthorized, gin.H{
-					"error": gin.H{
-						"code":    "email_verification_required",
-						"message": "メールアドレスの認証が完了していません。確認メールのリンクから認証を完了してください。",
-					},
-				})
-				c.Abort()
+				httpresponse.AbortUnauthorized(c, errorCodeEmailVerificationRequired, errorMessageEmailVerificationRequired)
 				return
 			}
 		}
@@ -138,18 +127,18 @@ func permissionDeniedFields(c *gin.Context, reason string) []logger.Field {
 
 // requiresEmailVerification checks if the given path requires email verification
 func (m *AuthMiddleware) requiresEmailVerification(path string) bool {
-	// Skip email verification check for these paths
-	skipPaths := []string{
-		"/auth/register",
-		"/auth/login",
-		"/auth/email/verify",
-		"/auth/email/resend",
+	normalizedPath := strings.TrimPrefix(strings.TrimSpace(path), "/api/v1")
+
+	// Skip email verification check for auth public paths.
+	skipPaths := map[string]struct{}{
+		"/auth/register":     {},
+		"/auth/login":        {},
+		"/auth/email/verify": {},
+		"/auth/email/resend": {},
 	}
 
-	for _, skipPath := range skipPaths {
-		if path == skipPath {
-			return false
-		}
+	if _, ok := skipPaths[normalizedPath]; ok {
+		return false
 	}
 
 	return true

--- a/internal/app/middleware/auth_middleware_test.go
+++ b/internal/app/middleware/auth_middleware_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"business/internal/app/httpresponse"
 	"business/internal/auth/domain"
 	"business/internal/library/logger"
 	mocklibrary "business/test/mock/library"
@@ -45,6 +46,12 @@ func generateToken(secret string, userID uint, expiresAt time.Time) string {
 	return signedToken
 }
 
+func assertStandardErrorResponse(t *testing.T, resp *httptest.ResponseRecorder, status int, code, message string) {
+	t.Helper()
+	assert.Equal(t, status, resp.Code)
+	assert.JSONEq(t, `{"error":{"code":"`+code+`","message":"`+message+`"}}`, resp.Body.String())
+}
+
 func TestAuthMiddleware_Success(t *testing.T) {
 
 	secret := "test-secret"
@@ -63,13 +70,13 @@ func TestAuthMiddleware_Success(t *testing.T) {
 	router.GET("/protected", func(c *gin.Context) {
 		userID, exists := c.Get("userID")
 		if !exists {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "userID not found"})
+			httpresponse.AbortInternalServerError(c)
 			return
 		}
 
 		contextUserID, ok := logger.UserIDFromContext(c.Request.Context())
 		if !ok {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "context userID not found"})
+			httpresponse.AbortInternalServerError(c)
 			return
 		}
 
@@ -106,7 +113,7 @@ func TestAuthMiddleware_SuccessWithCookie(t *testing.T) {
 	router.GET("/protected", func(c *gin.Context) {
 		userID, exists := c.Get("userID")
 		if !exists {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "userID not found"})
+			httpresponse.AbortInternalServerError(c)
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"user_id": userID})
@@ -141,8 +148,7 @@ func TestAuthMiddleware_MissingTokenNoCredentials(t *testing.T) {
 
 	router.ServeHTTP(resp, req)
 
-	assert.Equal(t, http.StatusUnauthorized, resp.Code)
-	assert.JSONEq(t, `{"error":"missing token"}`, resp.Body.String())
+	assertStandardErrorResponse(t, resp, http.StatusUnauthorized, errorCodeMissingToken, errorMessageMissingToken)
 }
 
 func TestAuthMiddleware_IgnoresAuthorizationHeader(t *testing.T) {
@@ -165,8 +171,7 @@ func TestAuthMiddleware_IgnoresAuthorizationHeader(t *testing.T) {
 
 	router.ServeHTTP(resp, req)
 
-	assert.Equal(t, http.StatusUnauthorized, resp.Code)
-	assert.JSONEq(t, `{"error":"missing token"}`, resp.Body.String())
+	assertStandardErrorResponse(t, resp, http.StatusUnauthorized, errorCodeMissingToken, errorMessageMissingToken)
 }
 
 func TestAuthMiddleware_EmptyCookieValue(t *testing.T) {
@@ -187,8 +192,7 @@ func TestAuthMiddleware_EmptyCookieValue(t *testing.T) {
 
 	router.ServeHTTP(resp, req)
 
-	assert.Equal(t, http.StatusUnauthorized, resp.Code)
-	assert.JSONEq(t, `{"error":"missing token"}`, resp.Body.String())
+	assertStandardErrorResponse(t, resp, http.StatusUnauthorized, errorCodeMissingToken, errorMessageMissingToken)
 }
 
 func TestAuthMiddleware_SecretKeyNotSet(t *testing.T) {
@@ -209,8 +213,7 @@ func TestAuthMiddleware_SecretKeyNotSet(t *testing.T) {
 
 	router.ServeHTTP(resp, req)
 
-	assert.Equal(t, http.StatusInternalServerError, resp.Code)
-	assert.JSONEq(t, `{"error":"internal server error"}`, resp.Body.String())
+	assertStandardErrorResponse(t, resp, http.StatusInternalServerError, errorCodeInternalServerError, errorMessageInternalServerError)
 }
 
 func TestAuthMiddleware_InvalidSigningMethod(t *testing.T) {
@@ -241,8 +244,7 @@ func TestAuthMiddleware_InvalidSigningMethod(t *testing.T) {
 
 	router.ServeHTTP(resp, req)
 
-	assert.Equal(t, http.StatusUnauthorized, resp.Code)
-	assert.JSONEq(t, `{"error":"invalid token"}`, resp.Body.String())
+	assertStandardErrorResponse(t, resp, http.StatusUnauthorized, errorCodeInvalidToken, errorMessageInvalidToken)
 }
 
 func TestAuthMiddleware_ExpiredToken(t *testing.T) {
@@ -266,8 +268,7 @@ func TestAuthMiddleware_ExpiredToken(t *testing.T) {
 
 	router.ServeHTTP(resp, req)
 
-	assert.Equal(t, http.StatusUnauthorized, resp.Code)
-	assert.JSONEq(t, `{"error":"invalid token"}`, resp.Body.String())
+	assertStandardErrorResponse(t, resp, http.StatusUnauthorized, errorCodeInvalidToken, errorMessageInvalidToken)
 }
 
 func TestAuthMiddleware_InvalidToken(t *testing.T) {
@@ -288,8 +289,7 @@ func TestAuthMiddleware_InvalidToken(t *testing.T) {
 
 	router.ServeHTTP(resp, req)
 
-	assert.Equal(t, http.StatusUnauthorized, resp.Code)
-	assert.JSONEq(t, `{"error":"invalid token"}`, resp.Body.String())
+	assertStandardErrorResponse(t, resp, http.StatusUnauthorized, errorCodeInvalidToken, errorMessageInvalidToken)
 }
 
 func TestAuthMiddleware_EmailVerificationRequired(t *testing.T) {
@@ -316,9 +316,7 @@ func TestAuthMiddleware_EmailVerificationRequired(t *testing.T) {
 
 	router.ServeHTTP(resp, req)
 
-	assert.Equal(t, http.StatusUnauthorized, resp.Code)
-	assert.Contains(t, resp.Body.String(), "email_verification_required")
-	assert.Contains(t, resp.Body.String(), "メールアドレスの認証が完了していません")
+	assertStandardErrorResponse(t, resp, http.StatusUnauthorized, errorCodeEmailVerificationRequired, errorMessageEmailVerificationRequired)
 	users.AssertExpectations(t)
 }
 
@@ -331,10 +329,10 @@ func TestAuthMiddleware_SkipEmailVerificationForAuthPaths(t *testing.T) {
 	middleware := NewAuthMiddleware(osw, users, logger.NewNop())
 
 	testCases := []string{
-		"/auth/register",
-		"/auth/login",
-		"/auth/email/verify",
-		"/auth/email/resend",
+		"/api/v1/auth/register",
+		"/api/v1/auth/login",
+		"/api/v1/auth/email/verify",
+		"/api/v1/auth/email/resend",
 	}
 
 	for _, path := range testCases {
@@ -383,8 +381,7 @@ func TestAuthMiddleware_UserNotFoundDuringEmailVerificationCheck(t *testing.T) {
 
 	router.ServeHTTP(resp, req)
 
-	assert.Equal(t, http.StatusUnauthorized, resp.Code)
-	assert.JSONEq(t, `{"error":"user not found"}`, resp.Body.String())
+	assertStandardErrorResponse(t, resp, http.StatusUnauthorized, errorCodeUserNotFound, errorMessageUserNotFound)
 	users.AssertExpectations(t)
 }
 
@@ -406,7 +403,7 @@ func TestAuthMiddleware_MissingTokenLogsPermissionDenied(t *testing.T) {
 
 	router.ServeHTTP(resp, req)
 
-	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+	assertStandardErrorResponse(t, resp, http.StatusUnauthorized, errorCodeMissingToken, errorMessageMissingToken)
 	if assert.Len(t, spy.entries, 1) {
 		assert.Equal(t, "info", spy.entries[0].level)
 		assert.Equal(t, "permission_denied", spy.entries[0].message)

--- a/internal/app/middleware/error_catalog.go
+++ b/internal/app/middleware/error_catalog.go
@@ -1,0 +1,21 @@
+package middleware
+
+const (
+	errorCodeMissingToken              = "missing_token"
+	errorCodeInvalidToken              = "invalid_token"
+	errorCodeInvalidTokenClaims        = "invalid_token_claims"
+	errorCodeUserNotFound              = "user_not_found"
+	errorCodeEmailVerificationRequired = "email_verification_required"
+	errorCodeCSRFOriginNotAllowed      = "csrf_origin_not_allowed"
+	errorCodeInternalServerError       = "internal_server_error"
+)
+
+const (
+	errorMessageMissingToken              = "認証トークンがありません。"
+	errorMessageInvalidToken              = "認証トークンが無効です。"
+	errorMessageInvalidTokenClaims        = "認証トークンの内容が不正です。"
+	errorMessageUserNotFound              = "ユーザーが見つかりません。"
+	errorMessageEmailVerificationRequired = "メールアドレスの認証が完了していません。確認メールのリンクから認証を完了してください。"
+	errorMessageCSRFOriginNotAllowed      = "オリジンまたはリファラが許可されていません。"
+	errorMessageInternalServerError       = "サーバー内部でエラーが発生しました。しばらくしてから再度お試しください。"
+)

--- a/internal/app/middleware/origin_referer_check.go
+++ b/internal/app/middleware/origin_referer_check.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"business/internal/app/httpresponse"
 	"net/http"
 	"net/url"
 
@@ -41,6 +42,6 @@ func CsrfOriginCheck(allowedOrigins ...string) gin.HandlerFunc {
 			return
 		}
 
-		c.AbortWithStatus(http.StatusForbidden)
+		httpresponse.AbortForbidden(c, errorCodeCSRFOriginNotAllowed, errorMessageCSRFOriginNotAllowed)
 	}
 }

--- a/internal/app/middleware/origin_referer_check_test.go
+++ b/internal/app/middleware/origin_referer_check_test.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCsrfOriginCheck_AllowsConfiguredOrigin(t *testing.T) {
+	router := gin.New()
+	router.Use(CsrfOriginCheck("https://example.com"))
+	router.POST("/submit", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/submit", nil)
+	req.Header.Set("Origin", "https://example.com/form")
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusNoContent, resp.Code)
+	assert.Empty(t, resp.Body.String())
+}
+
+func TestCsrfOriginCheck_RejectsUnapprovedOriginWithStandardErrorResponse(t *testing.T) {
+	router := gin.New()
+	router.Use(CsrfOriginCheck("https://example.com"))
+	router.POST("/submit", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/submit", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusForbidden, resp.Code)
+	assert.JSONEq(t, `{"error":{"code":"csrf_origin_not_allowed","message":"オリジンまたはリファラが許可されていません。"}}`, resp.Body.String())
+}

--- a/internal/app/middleware/request_context.go
+++ b/internal/app/middleware/request_context.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"business/internal/app/httpresponse"
 	"business/internal/library/logger"
 	"business/internal/library/timewrapper"
 	"io"
@@ -31,7 +32,7 @@ func RequestID() gin.HandlerFunc {
 		c.Header(requestIDHeader, requestID)
 		requestCtx, err := logger.ContextWithRequestID(c.Request.Context(), requestID)
 		if err != nil {
-			c.AbortWithStatus(http.StatusInternalServerError)
+			httpresponse.AbortInternalServerError(c)
 			return
 		}
 
@@ -113,7 +114,7 @@ func Recovery(log logger.Interface) gin.HandlerFunc {
 			logger.HTTPStatusCode(http.StatusInternalServerError),
 			logger.StackTrace(),
 		)
-		c.AbortWithStatus(http.StatusInternalServerError)
+		httpresponse.AbortInternalServerError(c)
 	})
 }
 

--- a/internal/app/middleware/request_context_test.go
+++ b/internal/app/middleware/request_context_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"business/internal/app/httpresponse"
 	"business/internal/library/logger"
 	"context"
 	"net/http"
@@ -20,13 +21,13 @@ func TestRequestID_GeneratesRequestIDAndPropagatesToContext(t *testing.T) {
 	router.GET("/ping", func(c *gin.Context) {
 		requestID, exists := c.Get("request_id")
 		if !exists {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "request_id not found"})
+			httpresponse.AbortInternalServerError(c)
 			return
 		}
 
 		contextRequestID, ok := logger.RequestIDFromContext(c.Request.Context())
 		if !ok {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "context request_id not found"})
+			httpresponse.AbortInternalServerError(c)
 			return
 		}
 
@@ -70,6 +71,22 @@ func TestRequestID_UsesInboundRequestID(t *testing.T) {
 	assert.JSONEq(t, `{"request_id":"req-123","context_request_id":"req-123"}`, resp.Body.String())
 }
 
+func TestRecovery_WritesStandardErrorResponse(t *testing.T) {
+	router := gin.New()
+	router.Use(Recovery(logger.NewNop()))
+	router.GET("/panic", func(c *gin.Context) {
+		panic("boom")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.JSONEq(t, `{"error":{"code":"internal_server_error","message":"サーバー内部でエラーが発生しました。しばらくしてから再度お試しください。"}}`, resp.Body.String())
+}
+
 func TestRequestSummary_UsesContextFields(t *testing.T) {
 	router := gin.New()
 	router.Use(RequestID())
@@ -78,7 +95,7 @@ func TestRequestSummary_UsesContextFields(t *testing.T) {
 		c.Set("userID", uint(42))
 		requestCtx, err := logger.ContextWithUserID(c.Request.Context(), 42)
 		if err != nil {
-			c.Status(http.StatusInternalServerError)
+			httpresponse.AbortInternalServerError(c)
 			return
 		}
 

--- a/internal/app/presentation/auth/controller.go
+++ b/internal/app/presentation/auth/controller.go
@@ -31,12 +31,3 @@ type userResponse struct {
 	EmailVerifiedAt *time.Time `json:"email_verified_at"`
 	CreatedAt       time.Time  `json:"created_at"`
 }
-
-type errorResponse struct {
-	Error errorDetail `json:"error"`
-}
-
-type errorDetail struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-}

--- a/internal/app/presentation/auth/email_verification_controller.go
+++ b/internal/app/presentation/auth/email_verification_controller.go
@@ -1,11 +1,13 @@
 package auth
 
 import (
+	"business/internal/app/httpresponse"
 	"business/internal/auth/application"
 	"business/internal/auth/domain"
 	"business/internal/library/logger"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -13,6 +15,10 @@ import (
 type verifyEmailResponse struct {
 	Message string       `json:"message"`
 	User    userResponse `json:"user"`
+}
+
+type verifyEmailRequest struct {
+	Token string `json:"token"`
 }
 
 type resendVerificationRequest struct {
@@ -24,23 +30,23 @@ type resendVerificationResponse struct {
 	Message string `json:"message"`
 }
 
-// VerifyEmail handles the GET /auth/email/verify endpoint.
+// VerifyEmail handles the POST /api/v1/auth/email/verify endpoint.
 func (lc *Controller) VerifyEmail(c *gin.Context) {
 	reqLog, err := lc.logger.WithContext(c.Request.Context())
 	if err != nil {
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
-	token := c.Query("token")
+	var req verifyEmailRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpresponse.WriteInvalidRequest(c)
+		return
+	}
 
+	token := strings.TrimSpace(req.Token)
 	if token == "" {
-		c.JSON(http.StatusBadRequest, errorResponse{
-			Error: errorDetail{
-				Code:    "missing_token",
-				Message: "トークンが指定されていません。",
-			},
-		})
+		httpresponse.WriteError(c, http.StatusBadRequest, "missing_token", "トークンが指定されていません。")
 		return
 	}
 
@@ -49,34 +55,19 @@ func (lc *Controller) VerifyEmail(c *gin.Context) {
 	})
 	if err != nil {
 		if errors.Is(err, application.ErrInvalidToken) {
-			c.JSON(http.StatusBadRequest, errorResponse{
-				Error: errorDetail{
-					Code:    "invalid_token",
-					Message: "無効なトークンです。",
-				},
-			})
+			httpresponse.WriteError(c, http.StatusBadRequest, "invalid_token", "無効なトークンです。")
 			return
 		}
 		if errors.Is(err, application.ErrTokenExpired) {
-			c.JSON(http.StatusBadRequest, errorResponse{
-				Error: errorDetail{
-					Code:    "token_expired",
-					Message: "トークンの有効期限が切れています。再送信をお試しください。",
-				},
-			})
+			httpresponse.WriteError(c, http.StatusConflict, "token_expired", "トークンの有効期限が切れています。再送信をお試しください。")
 			return
 		}
 		if errors.Is(err, application.ErrTokenAlreadyUsed) {
-			c.JSON(http.StatusBadRequest, errorResponse{
-				Error: errorDetail{
-					Code:    "token_already_used",
-					Message: "このトークンは既に使用済みです。",
-				},
-			})
+			httpresponse.WriteError(c, http.StatusConflict, "token_already_used", "このトークンは既に使用済みです。")
 			return
 		}
 		reqLog.Error("VerifyEmail error", logger.Err(err))
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
@@ -93,17 +84,17 @@ func (lc *Controller) VerifyEmail(c *gin.Context) {
 	})
 }
 
-// ResendVerificationEmail handles the POST /auth/email/resend endpoint.
+// ResendVerificationEmail handles the POST /api/v1/auth/email/resend endpoint.
 func (lc *Controller) ResendVerificationEmail(c *gin.Context) {
 	var req resendVerificationRequest
 	reqLog, err := lc.logger.WithContext(c.Request.Context())
 	if err != nil {
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.Status(http.StatusBadRequest)
+		httpresponse.WriteInvalidRequest(c)
 		return
 	}
 
@@ -113,43 +104,23 @@ func (lc *Controller) ResendVerificationEmail(c *gin.Context) {
 	})
 	if err != nil {
 		if errors.Is(err, application.ErrInvalidCredentials) {
-			c.JSON(http.StatusUnauthorized, errorResponse{
-				Error: errorDetail{
-					Code:    "invalid_credentials",
-					Message: "メールアドレスまたはパスワードが正しくありません。",
-				},
-			})
+			httpresponse.WriteError(c, http.StatusUnauthorized, "invalid_credentials", "メールアドレスまたはパスワードが正しくありません。")
 			return
 		}
 		if errors.Is(err, application.ErrAlreadyVerified) {
-			c.JSON(http.StatusBadRequest, errorResponse{
-				Error: errorDetail{
-					Code:    "already_verified",
-					Message: "このメールアドレスは既に認証済みです。",
-				},
-			})
+			httpresponse.WriteError(c, http.StatusForbidden, "already_verified", "このメールアドレスは既に認証済みです。")
 			return
 		}
 		if errors.Is(err, application.ErrRateLimitExceeded) {
-			c.JSON(http.StatusTooManyRequests, errorResponse{
-				Error: errorDetail{
-					Code:    "rate_limit_exceeded",
-					Message: "再送信の回数制限に達しました。15分後に再度お試しください。",
-				},
-			})
+			httpresponse.WriteError(c, http.StatusTooManyRequests, "rate_limit_exceeded", "再送信の回数制限に達しました。15分後に再度お試しください。")
 			return
 		}
 		if errors.Is(err, application.ErrMailSendFailed) {
-			c.JSON(http.StatusInternalServerError, errorResponse{
-				Error: errorDetail{
-					Code:    "mail_send_failed",
-					Message: "メール送信に失敗しました。しばらくしてから再度お試しください。",
-				},
-			})
+			httpresponse.WriteServiceUnavailable(c, "mail_send_failed", "メール送信に失敗しました。しばらくしてから再度お試しください。")
 			return
 		}
 		reqLog.Error("ResendVerificationEmail error", logger.Err(err))
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 

--- a/internal/app/presentation/auth/email_verification_controller_test.go
+++ b/internal/app/presentation/auth/email_verification_controller_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,7 +19,7 @@ import (
 func TestVerifyEmailController(t *testing.T) {
 	t.Parallel()
 
-	t.Run("success", func(t *testing.T) {
+	t.Run("POST success", func(t *testing.T) {
 		t.Parallel()
 		usecase := new(mockAuthUseCase)
 		now := time.Now()
@@ -34,9 +35,10 @@ func TestVerifyEmailController(t *testing.T) {
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.GET("/auth/email/verify", controller.VerifyEmail)
+		router.POST("/api/v1/auth/email/verify", controller.VerifyEmail)
 
-		req := httptest.NewRequest(http.MethodGet, "/auth/email/verify?token=valid-token-123", nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/verify", bytes.NewBuffer([]byte(`{"token":"valid-token-123"}`)))
+		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
@@ -48,81 +50,101 @@ func TestVerifyEmailController(t *testing.T) {
 		usecase.AssertExpectations(t)
 	})
 
-	t.Run("missing token", func(t *testing.T) {
+	t.Run("POST missing token", func(t *testing.T) {
 		t.Parallel()
 		usecase := new(mockAuthUseCase)
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.GET("/auth/email/verify", controller.VerifyEmail)
+		router.POST("/api/v1/auth/email/verify", controller.VerifyEmail)
 
-		req := httptest.NewRequest(http.MethodGet, "/auth/email/verify", nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/verify", bytes.NewBuffer([]byte(`{}`)))
+		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusBadRequest, resp.Code)
-		assert.Contains(t, resp.Body.String(), "missing_token")
-		assert.Contains(t, resp.Body.String(), "トークンが指定されていません")
+		assert.JSONEq(t, `{"error":{"code":"missing_token","message":"トークンが指定されていません。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 
-	t.Run("invalid token", func(t *testing.T) {
+	t.Run("POST invalid token", func(t *testing.T) {
 		t.Parallel()
 		usecase := new(mockAuthUseCase)
 		usecase.On("VerifyEmail", mock.Anything, mock.Anything).Return(domain.User{}, application.ErrInvalidToken).Once()
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.GET("/auth/email/verify", controller.VerifyEmail)
+		router.POST("/api/v1/auth/email/verify", controller.VerifyEmail)
 
-		req := httptest.NewRequest(http.MethodGet, "/auth/email/verify?token=invalid-token", nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/verify", bytes.NewBuffer([]byte(`{"token":"invalid-token"}`)))
+		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusBadRequest, resp.Code)
-		assert.Contains(t, resp.Body.String(), "invalid_token")
-		assert.Contains(t, resp.Body.String(), "無効なトークンです")
+		assert.JSONEq(t, `{"error":{"code":"invalid_token","message":"無効なトークンです。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 
-	t.Run("token expired", func(t *testing.T) {
+	t.Run("POST token expired", func(t *testing.T) {
 		t.Parallel()
 		usecase := new(mockAuthUseCase)
 		usecase.On("VerifyEmail", mock.Anything, mock.Anything).Return(domain.User{}, application.ErrTokenExpired).Once()
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.GET("/auth/email/verify", controller.VerifyEmail)
+		router.POST("/api/v1/auth/email/verify", controller.VerifyEmail)
 
-		req := httptest.NewRequest(http.MethodGet, "/auth/email/verify?token=expired-token", nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/verify", bytes.NewBuffer([]byte(`{"token":"expired-token"}`)))
+		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
-		assert.Contains(t, resp.Body.String(), "token_expired")
-		assert.Contains(t, resp.Body.String(), "有効期限が切れています")
+		assert.Equal(t, http.StatusConflict, resp.Code)
+		assert.JSONEq(t, `{"error":{"code":"token_expired","message":"トークンの有効期限が切れています。再送信をお試しください。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 
-	t.Run("token already used", func(t *testing.T) {
+	t.Run("POST token already used", func(t *testing.T) {
 		t.Parallel()
 		usecase := new(mockAuthUseCase)
 		usecase.On("VerifyEmail", mock.Anything, mock.Anything).Return(domain.User{}, application.ErrTokenAlreadyUsed).Once()
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.GET("/auth/email/verify", controller.VerifyEmail)
+		router.POST("/api/v1/auth/email/verify", controller.VerifyEmail)
 
-		req := httptest.NewRequest(http.MethodGet, "/auth/email/verify?token=used-token", nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/verify", bytes.NewBuffer([]byte(`{"token":"used-token"}`)))
+		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
-		assert.Contains(t, resp.Body.String(), "token_already_used")
-		assert.Contains(t, resp.Body.String(), "既に使用済みです")
+		assert.Equal(t, http.StatusConflict, resp.Code)
+		assert.JSONEq(t, `{"error":{"code":"token_already_used","message":"このトークンは既に使用済みです。"}}`, resp.Body.String())
+		usecase.AssertExpectations(t)
+	})
+
+	t.Run("POST internal error", func(t *testing.T) {
+		t.Parallel()
+		usecase := new(mockAuthUseCase)
+		usecase.On("VerifyEmail", mock.Anything, mock.Anything).Return(domain.User{}, errors.New("db error")).Once()
+
+		controller := newTestController(usecase, newTestLogger())
+		router := gin.New()
+		router.POST("/api/v1/auth/email/verify", controller.VerifyEmail)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/verify", bytes.NewBuffer([]byte(`{"token":"internal-error-token"}`)))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+
+		router.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.JSONEq(t, `{"error":{"code":"internal_server_error","message":"サーバー内部でエラーが発生しました。しばらくしてから再度お試しください。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 }
@@ -139,10 +161,10 @@ func TestResendVerificationEmailController(t *testing.T) {
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.POST("/auth/email/resend", controller.ResendVerificationEmail)
+		router.POST("/api/v1/auth/email/resend", controller.ResendVerificationEmail)
 
 		reqBody := []byte(`{"email":"test@example.com","password":"password123"}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/email/resend", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/resend", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
@@ -160,17 +182,17 @@ func TestResendVerificationEmailController(t *testing.T) {
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.POST("/auth/email/resend", controller.ResendVerificationEmail)
+		router.POST("/api/v1/auth/email/resend", controller.ResendVerificationEmail)
 
 		reqBody := []byte(`{"email":"test@example.com","password":"wrong"}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/email/resend", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/resend", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusUnauthorized, resp.Code)
-		assert.Contains(t, resp.Body.String(), "invalid_credentials")
+		assert.JSONEq(t, `{"error":{"code":"invalid_credentials","message":"メールアドレスまたはパスワードが正しくありません。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 
@@ -181,17 +203,17 @@ func TestResendVerificationEmailController(t *testing.T) {
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.POST("/auth/email/resend", controller.ResendVerificationEmail)
+		router.POST("/api/v1/auth/email/resend", controller.ResendVerificationEmail)
 
 		reqBody := []byte(`{"email":"verified@example.com","password":"password123"}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/email/resend", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/resend", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
-		assert.Contains(t, resp.Body.String(), "already_verified")
+		assert.Equal(t, http.StatusForbidden, resp.Code)
+		assert.JSONEq(t, `{"error":{"code":"already_verified","message":"このメールアドレスは既に認証済みです。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 
@@ -202,17 +224,17 @@ func TestResendVerificationEmailController(t *testing.T) {
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.POST("/auth/email/resend", controller.ResendVerificationEmail)
+		router.POST("/api/v1/auth/email/resend", controller.ResendVerificationEmail)
 
 		reqBody := []byte(`{"email":"test@example.com","password":"password123"}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/email/resend", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/resend", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusTooManyRequests, resp.Code)
-		assert.Contains(t, resp.Body.String(), "rate_limit_exceeded")
+		assert.JSONEq(t, `{"error":{"code":"rate_limit_exceeded","message":"再送信の回数制限に達しました。15分後に再度お試しください。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 
@@ -223,17 +245,38 @@ func TestResendVerificationEmailController(t *testing.T) {
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.POST("/auth/email/resend", controller.ResendVerificationEmail)
+		router.POST("/api/v1/auth/email/resend", controller.ResendVerificationEmail)
 
 		reqBody := []byte(`{"email":"test@example.com","password":"password123"}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/email/resend", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/resend", bytes.NewBuffer(reqBody))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+
+		router.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, resp.Code)
+		assert.JSONEq(t, `{"error":{"code":"mail_send_failed","message":"メール送信に失敗しました。しばらくしてから再度お試しください。"}}`, resp.Body.String())
+		usecase.AssertExpectations(t)
+	})
+
+	t.Run("internal error", func(t *testing.T) {
+		t.Parallel()
+		usecase := new(mockAuthUseCase)
+		usecase.On("ResendVerificationEmail", mock.Anything, mock.Anything).Return(errors.New("db error")).Once()
+
+		controller := newTestController(usecase, newTestLogger())
+		router := gin.New()
+		router.POST("/api/v1/auth/email/resend", controller.ResendVerificationEmail)
+
+		reqBody := []byte(`{"email":"test@example.com","password":"password123"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/email/resend", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusInternalServerError, resp.Code)
-		assert.Contains(t, resp.Body.String(), "mail_send_failed")
+		assert.JSONEq(t, `{"error":{"code":"internal_server_error","message":"サーバー内部でエラーが発生しました。しばらくしてから再度お試しください。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 }

--- a/internal/app/presentation/auth/registration_controller.go
+++ b/internal/app/presentation/auth/registration_controller.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"business/internal/app/httpresponse"
 	"business/internal/auth/application"
 	"business/internal/auth/domain"
 	"business/internal/library/logger"
@@ -21,17 +22,17 @@ type registerResponse struct {
 	User    userResponse `json:"user"`
 }
 
-// Register handles account registration for the POST /auth/register endpoint.
+// Register handles account registration for the POST /api/v1/auth/register endpoint.
 func (lc *Controller) Register(c *gin.Context) {
 	var req registerRequest
 	reqLog, err := lc.logger.WithContext(c.Request.Context())
 	if err != nil {
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.Status(http.StatusBadRequest)
+		httpresponse.WriteInvalidRequest(c)
 		return
 	}
 
@@ -42,34 +43,19 @@ func (lc *Controller) Register(c *gin.Context) {
 	})
 	if err != nil {
 		if errors.Is(err, application.ErrEmailAlreadyExists) {
-			c.JSON(http.StatusBadRequest, errorResponse{
-				Error: errorDetail{
-					Code:    "email_already_exists",
-					Message: "このメールアドレスは既に登録されています。",
-				},
-			})
+			httpresponse.WriteError(c, http.StatusConflict, "email_already_exists", "このメールアドレスは既に登録されています。")
 			return
 		}
 		if errors.Is(err, application.ErrInvalidInput) {
-			c.JSON(http.StatusBadRequest, errorResponse{
-				Error: errorDetail{
-					Code:    "invalid_input",
-					Message: "入力値が不正です。",
-				},
-			})
+			httpresponse.WriteError(c, http.StatusBadRequest, "invalid_input", "入力値が不正です。")
 			return
 		}
 		if errors.Is(err, application.ErrMailSendFailed) {
-			c.JSON(http.StatusInternalServerError, errorResponse{
-				Error: errorDetail{
-					Code:    "mail_send_failed",
-					Message: "メール送信に失敗しました。しばらくしてから再度お試しください。",
-				},
-			})
+			httpresponse.WriteServiceUnavailable(c, "mail_send_failed", "メール送信に失敗しました。しばらくしてから再度お試しください。")
 			return
 		}
 		reqLog.Error("Register error", logger.Err(err))
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 

--- a/internal/app/presentation/auth/registration_controller_test.go
+++ b/internal/app/presentation/auth/registration_controller_test.go
@@ -32,10 +32,10 @@ func TestRegistrationController(t *testing.T) {
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.POST("/auth/register", controller.Register)
+		router.POST("/api/v1/auth/register", controller.Register)
 
 		reqBody := []byte(`{"email":"new@example.com","name":"New User","password":"password123"}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/register", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
@@ -53,16 +53,17 @@ func TestRegistrationController(t *testing.T) {
 		usecase := new(mockAuthUseCase)
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.POST("/auth/register", controller.Register)
+		router.POST("/api/v1/auth/register", controller.Register)
 
 		reqBody := []byte(`{"email":"invalid","name":"","password":""}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/register", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.JSONEq(t, `{"error":{"code":"invalid_request","message":"入力値が不正です。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 
@@ -73,17 +74,17 @@ func TestRegistrationController(t *testing.T) {
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.POST("/auth/register", controller.Register)
+		router.POST("/api/v1/auth/register", controller.Register)
 
 		reqBody := []byte(`{"email":"dup@example.com","name":"Dup","password":"password123"}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/register", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
-		assert.Contains(t, resp.Body.String(), "email_already_exists")
+		assert.Equal(t, http.StatusConflict, resp.Code)
+		assert.JSONEq(t, `{"error":{"code":"email_already_exists","message":"このメールアドレスは既に登録されています。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 
@@ -94,17 +95,17 @@ func TestRegistrationController(t *testing.T) {
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.POST("/auth/register", controller.Register)
+		router.POST("/api/v1/auth/register", controller.Register)
 
 		reqBody := []byte(`{"email":"user@example.com","name":"User","password":"password123"}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/register", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
-		assert.Equal(t, http.StatusInternalServerError, resp.Code)
-		assert.Contains(t, resp.Body.String(), "mail_send_failed")
+		assert.Equal(t, http.StatusServiceUnavailable, resp.Code)
+		assert.JSONEq(t, `{"error":{"code":"mail_send_failed","message":"メール送信に失敗しました。しばらくしてから再度お試しください。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 
@@ -115,16 +116,17 @@ func TestRegistrationController(t *testing.T) {
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.POST("/auth/register", controller.Register)
+		router.POST("/api/v1/auth/register", controller.Register)
 
 		reqBody := []byte(`{"email":"user@example.com","name":"User","password":"password123"}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/register", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/register", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.JSONEq(t, `{"error":{"code":"internal_server_error","message":"サーバー内部でエラーが発生しました。しばらくしてから再度お試しください。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 }

--- a/internal/app/presentation/auth/session_controller.go
+++ b/internal/app/presentation/auth/session_controller.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"business/internal/app/httpresponse"
 	"business/internal/auth/application"
 	"business/internal/auth/domain"
 	"business/internal/library/logger"
@@ -20,12 +21,12 @@ type checkResponse struct {
 	UserID uint `json:"user_id"`
 }
 
-// Login handles the POST /auth/login endpoint.
+// Login handles the POST /api/v1/auth/login endpoint.
 func (lc *Controller) Login(c *gin.Context) {
 	var req loginRequest
 	reqLog, err := lc.logger.WithContext(c.Request.Context())
 	if err != nil {
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
@@ -34,7 +35,7 @@ func (lc *Controller) Login(c *gin.Context) {
 			logger.String("reason", "invalid_request"),
 			logger.HTTPStatusCode(http.StatusBadRequest),
 		)
-		c.Status(http.StatusBadRequest)
+		httpresponse.WriteInvalidRequest(c)
 		return
 	}
 
@@ -48,7 +49,7 @@ func (lc *Controller) Login(c *gin.Context) {
 				logger.String("reason", "invalid_credentials"),
 				logger.HTTPStatusCode(http.StatusUnauthorized),
 			)
-			c.Status(http.StatusUnauthorized)
+			httpresponse.WriteError(c, http.StatusUnauthorized, "invalid_credentials", "メールアドレスまたはパスワードが正しくありません。")
 			return
 		}
 		reqLog.Error("login_failed",
@@ -56,7 +57,7 @@ func (lc *Controller) Login(c *gin.Context) {
 			logger.HTTPStatusCode(http.StatusInternalServerError),
 			logger.Err(err),
 		)
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
@@ -68,7 +69,7 @@ func (lc *Controller) Login(c *gin.Context) {
 			logger.HTTPStatusCode(http.StatusInternalServerError),
 			logger.Err(err),
 		)
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
@@ -79,7 +80,7 @@ func (lc *Controller) Login(c *gin.Context) {
 			logger.HTTPStatusCode(http.StatusInternalServerError),
 			logger.Err(err),
 		)
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
@@ -134,25 +135,25 @@ func (lc *Controller) cookieDomain() (string, error) {
 	return domain, nil
 }
 
-// Logout handles the POST /auth/logout endpoint.
+// Logout handles the POST /api/v1/auth/logout endpoint.
 func (lc *Controller) Logout(c *gin.Context) {
 	reqLog, err := lc.logger.WithContext(c.Request.Context())
 	if err != nil {
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
 	secure, err := lc.secureCookieEnabled()
 	if err != nil {
 		reqLog.Error("failed to determine cookie security", logger.Err(err))
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
 	domain, err := lc.cookieDomain()
 	if err != nil {
 		reqLog.Error("failed to determine cookie domain", logger.Err(err))
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
@@ -169,25 +170,25 @@ func (lc *Controller) Logout(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// Check handles the GET /auth/check endpoint.
+// Check handles the GET /api/v1/auth/check endpoint.
 func (lc *Controller) Check(c *gin.Context) {
 	reqLog, err := lc.logger.WithContext(c.Request.Context())
 	if err != nil {
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
 	userID, exists := c.Get("userID")
 	if !exists {
 		reqLog.Error("Check error: userID not found in context")
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
 	uid, ok := userID.(uint)
 	if !ok {
 		reqLog.Error("Check error: userID type assertion failed")
-		c.Status(http.StatusInternalServerError)
+		httpresponse.WriteInternalServerError(c)
 		return
 	}
 

--- a/internal/app/presentation/auth/session_controller_test.go
+++ b/internal/app/presentation/auth/session_controller_test.go
@@ -28,10 +28,10 @@ func TestLoginController(t *testing.T) {
 
 		controller := newTestControllerWithVars(usecase, log, map[string]string{"APP": "local"})
 		router := gin.New()
-		router.POST("/auth/login", controller.Login)
+		router.POST("/api/v1/auth/login", controller.Login)
 
 		reqBody := []byte(`{"email":"user@example.com","password":"password123"}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
@@ -63,17 +63,17 @@ func TestLoginController(t *testing.T) {
 		usecase := new(mockAuthUseCase)
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.POST("/auth/login", controller.Login)
+		router.POST("/api/v1/auth/login", controller.Login)
 
 		reqBody := []byte(`{"email":"","password":""}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusBadRequest, resp.Code)
-		assert.Empty(t, resp.Body.String())
+		assert.JSONEq(t, `{"error":{"code":"invalid_request","message":"入力値が不正です。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 
@@ -88,16 +88,17 @@ func TestLoginController(t *testing.T) {
 
 		controller := newTestController(usecase, log)
 		router := gin.New()
-		router.POST("/auth/login", controller.Login)
+		router.POST("/api/v1/auth/login", controller.Login)
 
 		reqBody := []byte(`{"email":"user@example.com","password":"wrong"}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusUnauthorized, resp.Code)
+		assert.JSONEq(t, `{"error":{"code":"invalid_credentials","message":"メールアドレスまたはパスワードが正しくありません。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 		if assert.Len(t, log.Entries, 1) {
 			assert.Equal(t, "info", log.Entries[0].Level)
@@ -115,16 +116,17 @@ func TestLoginController(t *testing.T) {
 
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.POST("/auth/login", controller.Login)
+		router.POST("/api/v1/auth/login", controller.Login)
 
 		reqBody := []byte(`{"email":"user@example.com","password":"password"}`)
-		req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewBuffer(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.JSONEq(t, `{"error":{"code":"internal_server_error","message":"サーバー内部でエラーが発生しました。しばらくしてから再度お試しください。"}}`, resp.Body.String())
 		usecase.AssertExpectations(t)
 	})
 }
@@ -133,9 +135,9 @@ func TestLogoutControllerClearsCookie(t *testing.T) {
 	t.Parallel()
 	controller := newTestController(new(mockAuthUseCase), newTestLogger())
 	router := gin.New()
-	router.POST("/auth/logout", controller.Logout)
+	router.POST("/api/v1/auth/logout", controller.Logout)
 
-	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
 	resp := httptest.NewRecorder()
 
 	router.ServeHTTP(resp, req)
@@ -158,9 +160,9 @@ func TestLogoutControllerMarksSecureWhenNeeded(t *testing.T) {
 	t.Parallel()
 	controller := newTestControllerWithVars(new(mockAuthUseCase), newTestLogger(), map[string]string{"APP": "production"})
 	router := gin.New()
-	router.POST("/auth/logout", controller.Logout)
+	router.POST("/api/v1/auth/logout", controller.Logout)
 
-	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
 	resp := httptest.NewRecorder()
 
 	router.ServeHTTP(resp, req)
@@ -180,9 +182,9 @@ func TestCheckController(t *testing.T) {
 			c.Set("userID", uint(123))
 			c.Next()
 		})
-		router.GET("/auth/check", controller.Check)
+		router.GET("/api/v1/auth/check", controller.Check)
 
-		req := httptest.NewRequest(http.MethodGet, "/auth/check", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/check", nil)
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
@@ -195,15 +197,15 @@ func TestCheckController(t *testing.T) {
 		usecase := new(mockAuthUseCase)
 		controller := newTestController(usecase, newTestLogger())
 		router := gin.New()
-		router.GET("/auth/check", controller.Check)
+		router.GET("/api/v1/auth/check", controller.Check)
 
-		req := httptest.NewRequest(http.MethodGet, "/auth/check", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/check", nil)
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusInternalServerError, resp.Code)
-		assert.Empty(t, resp.Body.String())
+		assert.JSONEq(t, `{"error":{"code":"internal_server_error","message":"サーバー内部でエラーが発生しました。しばらくしてから再度お試しください。"}}`, resp.Body.String())
 	})
 
 	t.Run("userID wrong type", func(t *testing.T) {
@@ -214,14 +216,14 @@ func TestCheckController(t *testing.T) {
 			c.Set("userID", "not-a-uint")
 			c.Next()
 		})
-		router.GET("/auth/check", controller.Check)
+		router.GET("/api/v1/auth/check", controller.Check)
 
-		req := httptest.NewRequest(http.MethodGet, "/auth/check", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/check", nil)
 		resp := httptest.NewRecorder()
 
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusInternalServerError, resp.Code)
-		assert.Empty(t, resp.Body.String())
+		assert.JSONEq(t, `{"error":{"code":"internal_server_error","message":"サーバー内部でエラーが発生しました。しばらくしてから再度お試しください。"}}`, resp.Body.String())
 	})
 }

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -11,6 +11,9 @@ import (
 )
 
 func NewRouter(g *gin.Engine, container *dig.Container, log logger.Interface) (*gin.Engine, error) {
+	g.GET("/api/v1", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
 	g.GET("/", func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
@@ -25,15 +28,15 @@ func NewRouter(g *gin.Engine, container *dig.Container, log logger.Interface) (*
 		log.Error("failed to resolve auth controller or auth middleware", logger.Err(err))
 		return g, err
 	}
-	authGroup := g.Group("/auth")
-	{
-		authGroup.POST("/login", authController.Login)
-		authGroup.POST("/logout", authController.Logout)
-		authGroup.POST("/register", authController.Register)
-		authGroup.GET("/email/verify", authController.VerifyEmail)
-		authGroup.POST("/email/resend", authController.ResendVerificationEmail)
-		authGroup.GET("/check", authMiddleware.Authenticate(), authController.Check)
+	registerAuthRoutes := func(group *gin.RouterGroup) {
+		group.POST("/login", authController.Login)
+		group.POST("/logout", authController.Logout)
+		group.POST("/register", authController.Register)
+		group.POST("/email/verify", authController.VerifyEmail)
+		group.POST("/email/resend", authController.ResendVerificationEmail)
+		group.GET("/check", authMiddleware.Authenticate(), authController.Check)
 	}
+	registerAuthRoutes(g.Group("/api/v1/auth"))
 
 	return g, nil
 }

--- a/internal/app/router/router_test.go
+++ b/internal/app/router/router_test.go
@@ -2,9 +2,19 @@ package v1_test
 
 import (
 	"context"
+	"testing"
 	"time"
 
+	"business/internal/app/middleware"
+	authpresentation "business/internal/app/presentation/auth"
+	v1 "business/internal/app/router"
 	"business/internal/auth/domain"
+	"business/internal/library/logger"
+	mocklibrary "business/test/mock/library"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/dig"
 )
 
 type stubAuthUserProvider struct{}
@@ -38,3 +48,59 @@ func (s *stubAuthUseCase) ResendVerificationEmail(ctx context.Context, req domai
 type stubAgentUsecase struct{}
 
 type stubEmailCredentialUsecase struct{}
+
+func TestNewRouterRegistersVersionedAndLegacyRoutes(t *testing.T) {
+	t.Parallel()
+
+	g := gin.New()
+	container := dig.New()
+	osw := mocklibrary.NewOsWrapperMock(map[string]string{
+		"APP":            "local",
+		"DOMAIN":         "localhost",
+		"JWT_SECRET_KEY": "test-secret",
+	})
+	log := logger.NewNop()
+
+	err := container.Provide(func() *authpresentation.Controller {
+		return authpresentation.NewController(&stubAuthUseCase{}, log, osw)
+	})
+	assert.NoError(t, err)
+	err = container.Provide(func() *middleware.AuthMiddleware {
+		return middleware.NewAuthMiddleware(osw, &stubAuthUserProvider{}, log)
+	})
+	assert.NoError(t, err)
+
+	_, err = v1.NewRouter(g, container, log)
+	assert.NoError(t, err)
+
+	routes := map[string]struct{}{}
+	for _, route := range g.Routes() {
+		routes[route.Method+" "+route.Path] = struct{}{}
+	}
+
+	expectedRoutes := []string{
+		"GET /api/v1",
+		"GET /",
+		"POST /api/v1/auth/login",
+		"POST /api/v1/auth/logout",
+		"POST /api/v1/auth/register",
+		"POST /api/v1/auth/email/verify",
+		"POST /api/v1/auth/email/resend",
+		"GET /api/v1/auth/check",
+	}
+	for _, route := range expectedRoutes {
+		assert.Contains(t, routes, route)
+	}
+
+	unexpectedRoutes := []string{
+		"POST /auth/login",
+		"POST /auth/logout",
+		"POST /auth/register",
+		"POST /auth/email/verify",
+		"POST /auth/email/resend",
+		"GET /auth/check",
+	}
+	for _, route := range unexpectedRoutes {
+		assert.NotContains(t, routes, route)
+	}
+}

--- a/internal/auth/application/auth_usecase_test.go
+++ b/internal/auth/application/auth_usecase_test.go
@@ -515,10 +515,10 @@ func TestAuthUseCase_ResendVerificationEmailSuccess(t *testing.T) {
 	repo.On("GetActiveTokenForUser", mock.Anything, uint(1), fixedTime).Return(domain.EmailVerificationToken{}, gorm.ErrRecordNotFound).Once()
 	repo.On("CreateEmailVerificationToken", mock.Anything, mock.Anything).Return(domain.EmailVerificationToken{ID: 2, UserID: 1, Token: "new-token"}, nil).Once()
 	mailer.On("SendVerificationEmail", mock.Anything, mock.Anything, mock.MatchedBy(func(url string) bool {
-		return url == "https://example.com/auth/email/verify?token=new-token"
+		return url == "https://example.com/signup/verify?token=new-token"
 	})).Return(nil).Once()
 
-	stubOS := mocklibrary.NewOsWrapperMock(map[string]string{"EMAIL_VERIFICATION_BASE_URL": "https://example.com"})
+	stubOS := mocklibrary.NewOsWrapperMock(map[string]string{"FRONT_DOMAIN": "https://example.com"})
 	uc := NewAuthUseCase(repo, stubOS, mailer, &stubClock{now: fixedTime})
 
 	err = uc.ResendVerificationEmail(context.Background(), domain.ResendVerificationRequest{
@@ -672,7 +672,7 @@ func TestAuthUseCase_ResendVerificationEmailMailSendFailed(t *testing.T) {
 	mailer.On("SendVerificationEmail", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("smtp error")).Once()
 	repo.On("DeleteTokenByID", mock.Anything, uint(2)).Return(nil).Once()
 
-	stubOS := mocklibrary.NewOsWrapperMock(map[string]string{"EMAIL_VERIFICATION_BASE_URL": "https://example.com"})
+	stubOS := mocklibrary.NewOsWrapperMock(map[string]string{"FRONT_DOMAIN": "https://example.com"})
 	uc := NewAuthUseCase(repo, stubOS, mailer, &stubClock{now: fixedTime})
 
 	err = uc.ResendVerificationEmail(context.Background(), domain.ResendVerificationRequest{

--- a/internal/auth/application/resend_verification_email.go
+++ b/internal/auth/application/resend_verification_email.go
@@ -82,13 +82,13 @@ func (uc *AuthUseCase) ResendVerificationEmail(ctx context.Context, req domain.R
 	}
 
 	// Send verification email
-	baseURL, envErr := uc.osw.GetEnv("EMAIL_VERIFICATION_BASE_URL")
+	baseURL, envErr := uc.osw.GetEnv("FRONT_DOMAIN")
 	if envErr != nil || strings.TrimSpace(baseURL) == "" {
 		baseURL = "https://local.auth.example.com"
 	} else {
 		baseURL = strings.TrimSpace(baseURL)
 	}
-	verifyURL := fmt.Sprintf("%s/auth/email/verify?token=%s", baseURL, tokenToUse.Token)
+	verifyURL := fmt.Sprintf("%s/signup/verify?token=%s", baseURL, tokenToUse.Token)
 
 	err = uc.mailer.SendVerificationEmail(ctx, user, verifyURL)
 	if err != nil {


### PR DESCRIPTION
# 概要
API共通仕様設計書追加 既存APIを整合性がとれるように修正

## 変更内容の要約
### 1. エラーレスポンス形式の統一

- auth controller と middleware の両方で、標準エラー形式 `{"error":{"code":"...","message":"..."}}` に統一した
- 空ボディの `400` / `401` / `403` / `500` を減らした

### 2. 共通 helper の統合

- 共通 helper を `internal/app/httpresponse/error_response.go` に統合した
- middleware 固有の code/message は `internal/app/middleware/error_catalog.go` に分離した
- auth controller 側のローカル helper と middleware 側の `error_response.go` を統合・整理した

### 3. `/api/v1` への寄せ

- auth API の正規ルートを `/api/v1/auth/*` に寄せた
- router test / controller test / middleware test も `/api/v1` 前提に更新した

### 4. メール認証フローの整理

- メール認証の正規入口を frontend の `/signup/verify` に統一した
- 再送メールのリンク先も frontend に揃えた
- backend の verify API は `POST /api/v1/auth/email/verify` のみにした
- `GET /api/v1/auth/email/verify` は削除した

### 5. ステータスコードの見直し

- `email_already_exists` -> `409 Conflict`
- `already_verified` -> `403 Forbidden`
- `token_expired` -> `409 Conflict`
- `token_already_used` -> `409 Conflict`
- `mail_send_failed` -> `503 Service Unavailable`

### 6. ドキュメント更新

- `docs/api_design_rules.md` を今回の方針に合わせて更新した
  - `/api/v1` を正規契約とする
  - メール認証の正規入口は frontend
  - backend の verify 本体は `POST /api/v1/auth/email/verify`
  - 認証系の代表的なステータスコード例を追記

## 動作確認
- [x] TODOコメントを削除しています。TODOコメントを残す場合は妥当な理由があることを説明済みです。
- [x] 動作確認を行いました。
- [x] ローカル環境で`task test`が成功しています。
- [x] CIが成功しています。

## その他
- 懸念点があれば
