### PR TITLE
#15 MailAccountConnection 一覧・状態確認 API を実装

### DIFF
--- a/docs/spec/MailAccountConnectionList.md
+++ b/docs/spec/MailAccountConnectionList.md
@@ -1,0 +1,157 @@
+# MailAccountConnection 一覧 API 仕様
+
+本ドキュメントは、`MailAccountConnection` 一覧 API の最新の要件定義・設計内容を 1 ファイルに集約した仕様書である。
+
+参照元:
+- `tasks/20260320_mail_account_connection一覧状態api/要件定義.md`
+- `tasks/20260320_mail_account_connection一覧状態api/設計.md`
+
+## 1. 概要
+
+### 背景
+- 既存実装では Gmail OAuth の開始 API と callback API は存在する。
+- 一方で、ユーザーが自分の連携済みメールアカウントを一覧する API は未提供。
+- DDD 上の公開概念は `MailAccountConnection` だが、現行実装では `email_credentials` テーブルを backing store として利用している。
+
+### 目的
+- 認証済みユーザーが、自分自身のメール連携一覧を取得できるようにする。
+- 本 API は「設定済みの連携一覧」を返すことに責務を限定し、外部 provider への有効確認は行わない。
+- 現状は Gmail のみ対象だが、将来的な Outlook 等の追加に耐える HTTP 契約と責務分割にする。
+
+### 非スコープ
+- 連携状態のリアルタイム有効確認
+- 連携解除 API
+- 連携詳細単体取得 API
+- pending OAuth state の一覧表示
+- バッチ設定やメール取得実行 API
+- Outlook 実装そのもの
+
+## 2. API 契約
+
+### Endpoint
+- Method: `GET`
+- Path: `/api/v1/mail-account-connections`
+- Auth: required
+- Query: なし
+
+### Response 200
+```json
+{
+  "items": [
+    {
+      "id": 12,
+      "provider": "gmail",
+      "account_identifier": "user@gmail.com",
+      "created_at": "2026-03-19T12:34:56Z",
+      "updated_at": "2026-03-19T12:40:12Z"
+    }
+  ]
+}
+```
+
+### Response item
+- `id`
+  - connection record ID
+- `provider`
+  - `gmail`, 将来 `outlook` など
+- `account_identifier`
+  - provider 非依存の識別子
+  - Gmail では Gmail address
+- `created_at`
+  - 初回連携作成日時
+- `updated_at`
+  - 最終再連携日時
+
+### Error
+- `401 unauthorized`
+  - JWT 不正または未認証
+- `500 internal_server_error`
+  - DB 読み出し失敗など、一覧のベースデータ取得に失敗した場合
+
+### 契約上の注意
+- JSON フィールド名は `lower_snake_case` とする。
+- コレクションレスポンスは `items` を基本キーとする。
+- token 値や digest はレスポンスに含めない。
+- v1 ではページングを入れない。必要になった場合も `items` を維持したまま `next_cursor` などを追加する。
+
+## 3. 機能要件
+
+- 認証済みユーザーのみ利用できること。
+- 自分自身の `MailAccountConnection` のみ取得できること。
+- レスポンスはレコード単位の一覧で返すこと。
+- 各レコードに `provider` を含めること。
+- 各レコードに provider 非依存の `account_identifier` を含めること。
+- 各レコードに `created_at` と `updated_at` を含めること。
+- レスポンスや構造化ログにアクセストークン / リフレッシュトークン / digest / auth code を出さないこと。
+
+## 4. 取得方針
+
+本 API は connection の存在一覧を返すだけで、現在利用可能かどうかの判定は行わない。
+
+### 取得アルゴリズム
+1. `user_id` で `email_credentials` を一覧取得する。
+2. 各レコードを provider 非依存の view model に変換する。
+3. `items` 配列として返す。
+
+### 補足
+- pending OAuth state は `MailAccountConnection` ではないため本 API に含めない。
+- access token / refresh token / digest は storage にのみ使い、レスポンスには含めない。
+- `token_expiry` などの保持情報から状態推定も行わない。
+
+## 5. レイヤ設計
+
+### Presentation
+- `GET /api/v1/mail-account-connections` を追加する。
+- handler は `(*Controller).List` とする。
+- HTTP DTO は controller ファイル内に置く。
+- controller は認証済み `userID` を受け取り、application 層の一覧取得を呼び出して `items` を返す。
+
+### Application
+- `UseCaseInterface` に `ListConnections(ctx context.Context, userID uint) ([]ConnectionView, error)` を追加する。
+- authorize / callback と同じ `emailcredential` usecase に置く。
+- 一覧 API では provider への問い合わせやトークン復号は行わない。
+- `email_credentials` から取得した storage model を provider 非依存の read model に変換する。
+
+### Domain
+- `EmailCredential` は storage model として維持する。
+- 一覧 API 用に `ConnectionView` を追加する。
+- `ConnectionView` の field は `ID`, `Provider`, `AccountIdentifier`, `CreatedAt`, `UpdatedAt` とする。
+- 既存の `internal/common/domain.MailAccountConnection` は今回の API では再利用しない。
+
+### Infrastructure
+- Repository に `ListCredentialsByUser(ctx context.Context, userID uint) ([]domain.EmailCredential, error)` を追加する。
+- DB の `gmail_address` 列は内部実装として当面許容し、application で `account_identifier` に写像する。
+- 並び順は固定し、同一ユーザーの一覧を安定して返す。
+
+## 6. Provider 拡張方針
+
+- HTTP path は provider 非依存の collection path を維持する。
+- response item は `provider` と `account_identifier` を持つため、Outlook 追加時も shape を変えない。
+- 既存 DB の `gmail_address` 列は内部実装として当面許容する。
+- 2 つ目の provider 実装着手前に `account_identifier` 系の汎用列へ寄せる migration を別タスクで行うのが望ましい。
+- 将来、接続状態表示が必要になった場合は別 API または追加フィールドで扱う。v1 一覧 API の責務には含めない。
+
+## 7. テスト観点
+
+### Controller
+- 200 正常系
+- 401 未認証
+- 500 ベース一覧取得失敗
+
+### UseCase
+- credential 0 件
+- 複数件を provider 非依存 shape に変換できること
+- 一覧取得失敗時に error を返すこと
+
+### Repository
+- user 単位の一覧取得
+- 並び順の固定
+
+### Router
+- `GET /api/v1/mail-account-connections` が登録される
+
+## 8. 判断事項
+
+- v1 は単一一覧 API に集約し、単体 detail API は作らない。
+- v1 は live check を行わない。
+- 一覧 API は設定済み連携の存在を返すことに責務を限定する。

--- a/internal/app/presentation/mailaccountconnection/controller.go
+++ b/internal/app/presentation/mailaccountconnection/controller.go
@@ -43,6 +43,18 @@ type callbackResponse struct {
 	Message string `json:"message"`
 }
 
+type listConnectionsResponse struct {
+	Items []connectionResponseItem `json:"items"`
+}
+
+type connectionResponseItem struct {
+	ID                uint      `json:"id"`
+	Provider          string    `json:"provider"`
+	AccountIdentifier string    `json:"account_identifier"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
+}
+
 // Authorize handles POST /api/v1/mail-account-connections/gmail/authorize
 func (ctrl *Controller) Authorize(c *gin.Context) {
 	reqLog := ctrl.log
@@ -50,14 +62,8 @@ func (ctrl *Controller) Authorize(c *gin.Context) {
 		reqLog = l
 	}
 
-	userID, exists := c.Get("userID")
-	if !exists {
-		httpresponse.WriteError(c, http.StatusUnauthorized, "unauthorized", "認証が必要です。")
-		return
-	}
-	uid, ok := userID.(uint)
+	uid, ok := currentUserID(c)
 	if !ok {
-		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
@@ -81,14 +87,8 @@ func (ctrl *Controller) Callback(c *gin.Context) {
 		reqLog = l
 	}
 
-	userID, exists := c.Get("userID")
-	if !exists {
-		httpresponse.WriteError(c, http.StatusUnauthorized, "unauthorized", "認証が必要です。")
-		return
-	}
-	uid, ok := userID.(uint)
+	uid, ok := currentUserID(c)
 	if !ok {
-		httpresponse.WriteInternalServerError(c)
 		return
 	}
 
@@ -124,4 +124,53 @@ func (ctrl *Controller) Callback(c *gin.Context) {
 	c.JSON(http.StatusOK, callbackResponse{
 		Message: "Gmail連携が完了しました。",
 	})
+}
+
+// List handles GET /api/v1/mail-account-connections
+func (ctrl *Controller) List(c *gin.Context) {
+	reqLog := ctrl.log
+	if l, err := ctrl.log.WithContext(c.Request.Context()); err == nil {
+		reqLog = l
+	}
+
+	uid, ok := currentUserID(c)
+	if !ok {
+		return
+	}
+
+	connections, err := ctrl.usecase.ListConnections(c.Request.Context(), uid)
+	if err != nil {
+		reqLog.Error("list_connections_failed", logger.Err(err))
+		httpresponse.WriteInternalServerError(c)
+		return
+	}
+
+	items := make([]connectionResponseItem, 0, len(connections))
+	for _, connection := range connections {
+		items = append(items, connectionResponseItem{
+			ID:                connection.ID,
+			Provider:          connection.Provider,
+			AccountIdentifier: connection.AccountIdentifier,
+			CreatedAt:         connection.CreatedAt,
+			UpdatedAt:         connection.UpdatedAt,
+		})
+	}
+
+	c.JSON(http.StatusOK, listConnectionsResponse{Items: items})
+}
+
+func currentUserID(c *gin.Context) (uint, bool) {
+	userID, exists := c.Get("userID")
+	if !exists {
+		httpresponse.WriteError(c, http.StatusUnauthorized, "unauthorized", "認証が必要です。")
+		return 0, false
+	}
+
+	uid, ok := userID.(uint)
+	if !ok {
+		httpresponse.WriteInternalServerError(c)
+		return 0, false
+	}
+
+	return uid, true
 }

--- a/internal/app/presentation/mailaccountconnection/controller_test.go
+++ b/internal/app/presentation/mailaccountconnection/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"business/internal/emailcredential/application"
 	"business/internal/emailcredential/domain"
@@ -32,6 +33,12 @@ func authorizeRouter(ctrl *Controller) *gin.Engine {
 func callbackRouter(ctrl *Controller) *gin.Engine {
 	r := gin.New()
 	r.POST("/callback", func(c *gin.Context) { setUserID(c, 1) }, ctrl.Callback)
+	return r
+}
+
+func listRouter(ctrl *Controller) *gin.Engine {
+	r := gin.New()
+	r.GET("/connections", func(c *gin.Context) { setUserID(c, 1) }, ctrl.List)
 	return r
 }
 
@@ -194,5 +201,76 @@ func TestCallback_503_exchange_failed(t *testing.T) {
 
 	assert.Equal(t, http.StatusServiceUnavailable, resp.Code)
 	assert.Contains(t, resp.Body.String(), "gmail_oauth_exchange_failed")
+	uc.AssertExpectations(t)
+}
+
+func TestList_200(t *testing.T) {
+	t.Parallel()
+	createdAt := time.Date(2026, 3, 19, 12, 34, 56, 0, time.UTC)
+	updatedAt := time.Date(2026, 3, 19, 12, 40, 12, 0, time.UTC)
+
+	uc := new(mockUseCase)
+	uc.On("ListConnections", mock.Anything, uint(1)).Return([]domain.ConnectionView{
+		{
+			ID:                12,
+			Provider:          "gmail",
+			AccountIdentifier: "user@gmail.com",
+			CreatedAt:         createdAt,
+			UpdatedAt:         updatedAt,
+		},
+	}, nil).Once()
+
+	ctrl := newTestController(uc)
+	r := listRouter(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/connections", nil)
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.JSONEq(t, `{
+		"items": [
+			{
+				"id": 12,
+				"provider": "gmail",
+				"account_identifier": "user@gmail.com",
+				"created_at": "2026-03-19T12:34:56Z",
+				"updated_at": "2026-03-19T12:40:12Z"
+			}
+		]
+	}`, resp.Body.String())
+	uc.AssertExpectations(t)
+}
+
+func TestList_401_no_user(t *testing.T) {
+	t.Parallel()
+	uc := new(mockUseCase)
+	ctrl := newTestController(uc)
+
+	r := gin.New()
+	r.GET("/connections", ctrl.List)
+
+	req := httptest.NewRequest(http.MethodGet, "/connections", nil)
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+	assert.Contains(t, resp.Body.String(), "unauthorized")
+}
+
+func TestList_500_internal(t *testing.T) {
+	t.Parallel()
+	uc := new(mockUseCase)
+	uc.On("ListConnections", mock.Anything, uint(1)).Return(([]domain.ConnectionView)(nil), errors.New("db fail")).Once()
+
+	ctrl := newTestController(uc)
+	r := listRouter(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/connections", nil)
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.Contains(t, resp.Body.String(), "internal_server_error")
 	uc.AssertExpectations(t)
 }

--- a/internal/app/presentation/mailaccountconnection/test_helper_test.go
+++ b/internal/app/presentation/mailaccountconnection/test_helper_test.go
@@ -2,6 +2,7 @@ package mailaccountconnection
 
 import (
 	"business/internal/emailcredential/application"
+	"business/internal/emailcredential/domain"
 	"business/internal/library/logger"
 	mocklibrary "business/test/mock/library"
 	"context"
@@ -22,6 +23,12 @@ func (m *mockUseCase) Authorize(ctx context.Context, userID uint) (application.A
 func (m *mockUseCase) Callback(ctx context.Context, userID uint, code, state string) error {
 	args := m.Called(ctx, userID, code, state)
 	return args.Error(0)
+}
+
+func (m *mockUseCase) ListConnections(ctx context.Context, userID uint) ([]domain.ConnectionView, error) {
+	args := m.Called(ctx, userID)
+	connections, _ := args.Get(0).([]domain.ConnectionView)
+	return connections, args.Error(1)
 }
 
 func newTestLogger() logger.Interface {

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -52,6 +52,7 @@ func NewRouter(g *gin.Engine, container *dig.Container, log logger.Interface, al
 		return g, err
 	}
 	registerMailAccountConnectionRoutes := func(group *gin.RouterGroup) {
+		group.GET("", authMiddleware.Authenticate(), macController.List)
 		group.POST("/gmail/authorize", authMiddleware.Authenticate(), macController.Authorize)
 		group.POST("/gmail/callback", authMiddleware.Authenticate(), macController.Callback)
 	}

--- a/internal/app/router/router_test.go
+++ b/internal/app/router/router_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "business/internal/app/router"
 	"business/internal/auth/domain"
 	ecapp "business/internal/emailcredential/application"
+	ecdomain "business/internal/emailcredential/domain"
 	"business/internal/library/logger"
 	mocklibrary "business/test/mock/library"
 
@@ -84,6 +85,10 @@ func (s *stubEmailCredentialUsecase) Callback(ctx context.Context, userID uint, 
 	return nil
 }
 
+func (s *stubEmailCredentialUsecase) ListConnections(ctx context.Context, userID uint) ([]ecdomain.ConnectionView, error) {
+	return []ecdomain.ConnectionView{}, nil
+}
+
 func TestNewRouterRegistersVersionedAndLegacyRoutes(t *testing.T) {
 	t.Parallel()
 
@@ -128,6 +133,7 @@ func TestNewRouterRegistersVersionedAndLegacyRoutes(t *testing.T) {
 		"POST /api/v1/auth/email/verify",
 		"POST /api/v1/auth/email/resend",
 		"GET /api/v1/auth/check",
+		"GET /api/v1/mail-account-connections",
 		"POST /api/v1/mail-account-connections/gmail/authorize",
 		"POST /api/v1/mail-account-connections/gmail/callback",
 	}

--- a/internal/emailcredential/application/usecase.go
+++ b/internal/emailcredential/application/usecase.go
@@ -31,6 +31,7 @@ type Repository interface {
 	FindPendingStateByState(ctx context.Context, state string) (domain.OAuthPendingState, error)
 	ConsumePendingState(ctx context.Context, id uint, consumedAt time.Time) error
 	FindCredentialByUserAndGmail(ctx context.Context, userID uint, gmailAddress string) (domain.EmailCredential, error)
+	ListCredentialsByUser(ctx context.Context, userID uint) ([]domain.EmailCredential, error)
 	CreateCredential(ctx context.Context, cred domain.EmailCredential) error
 	UpdateCredentialTokens(ctx context.Context, cred domain.EmailCredential) error
 }
@@ -54,6 +55,7 @@ type GmailProfileFetcher interface {
 type UseCaseInterface interface {
 	Authorize(ctx context.Context, userID uint) (AuthorizeResult, error)
 	Callback(ctx context.Context, userID uint, code, state string) error
+	ListConnections(ctx context.Context, userID uint) ([]domain.ConnectionView, error)
 }
 
 // AuthorizeResult holds the result of the authorize use case.
@@ -314,6 +316,37 @@ func (uc *UseCase) Callback(ctx context.Context, userID uint, code, state string
 	}
 
 	return nil
+}
+
+// ListConnections lists the caller's stored mail account connections without probing the provider.
+func (uc *UseCase) ListConnections(ctx context.Context, userID uint) ([]domain.ConnectionView, error) {
+	reqLog := uc.log
+	if l, err := uc.log.WithContext(ctx); err == nil {
+		reqLog = l
+	}
+
+	credentials, err := uc.repo.ListCredentialsByUser(ctx, userID)
+	if err != nil {
+		reqLog.Error("credential_list_failed", logger.Err(err))
+		return nil, fmt.Errorf("failed to list credentials: %w", err)
+	}
+
+	if len(credentials) == 0 {
+		return []domain.ConnectionView{}, nil
+	}
+
+	connections := make([]domain.ConnectionView, 0, len(credentials))
+	for _, credential := range credentials {
+		connections = append(connections, domain.ConnectionView{
+			ID:                credential.ID,
+			Provider:          strings.ToLower(strings.TrimSpace(credential.Type)),
+			AccountIdentifier: strings.ToLower(strings.TrimSpace(credential.GmailAddress)),
+			CreatedAt:         credential.CreatedAt,
+			UpdatedAt:         credential.UpdatedAt,
+		})
+	}
+
+	return connections, nil
 }
 
 func (uc *UseCase) buildVault() (*crypto.Vault, error) {

--- a/internal/emailcredential/application/usecase_test.go
+++ b/internal/emailcredential/application/usecase_test.go
@@ -40,6 +40,12 @@ func (m *mockRepo) FindCredentialByUserAndGmail(ctx context.Context, userID uint
 	return args.Get(0).(domain.EmailCredential), args.Error(1)
 }
 
+func (m *mockRepo) ListCredentialsByUser(ctx context.Context, userID uint) ([]domain.EmailCredential, error) {
+	args := m.Called(ctx, userID)
+	credentials, _ := args.Get(0).([]domain.EmailCredential)
+	return credentials, args.Error(1)
+}
+
 func (m *mockRepo) CreateCredential(ctx context.Context, cred domain.EmailCredential) error {
 	args := m.Called(ctx, cred)
 	return args.Error(0)
@@ -111,6 +117,23 @@ func testToken() *oauth2.Token {
 		AccessToken:  "access-tok",
 		RefreshToken: "refresh-tok",
 		Expiry:       time.Date(2026, 3, 19, 13, 0, 0, 0, time.UTC),
+	}
+}
+
+func testListCredential(id uint, provider string, accountIdentifier string, createdAt time.Time) domain.EmailCredential {
+	return domain.EmailCredential{
+		ID:                 id,
+		UserID:             1,
+		Type:               provider,
+		GmailAddress:       accountIdentifier,
+		KeyVersion:         1,
+		AccessToken:        "unused-access-token",
+		AccessTokenDigest:  "unused-access-token-digest",
+		RefreshToken:       "unused-refresh-token",
+		RefreshTokenDigest: "unused-refresh-token-digest",
+		TokenExpiry:        nil,
+		CreatedAt:          createdAt,
+		UpdatedAt:          createdAt.Add(5 * time.Minute),
 	}
 }
 
@@ -444,5 +467,59 @@ func TestCallback_CredentialLookup_DBError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to look up credential")
 	assert.NotErrorIs(t, err, domain.ErrCredentialNotFound)
+	repo.AssertExpectations(t)
+}
+
+func TestListConnections_Empty(t *testing.T) {
+	t.Parallel()
+	repo := new(mockRepo)
+	now := time.Date(2026, 3, 20, 2, 0, 0, 0, time.UTC)
+
+	repo.On("ListCredentialsByUser", mock.Anything, uint(1)).Return([]domain.EmailCredential{}, nil)
+
+	uc := newTestUseCase(repo, new(mockOAuthCfg), nil, nil, testOSW(), testClock(now))
+	connections, err := uc.ListConnections(context.Background(), 1)
+
+	assert.NoError(t, err)
+	assert.Empty(t, connections)
+	repo.AssertExpectations(t)
+}
+
+func TestListConnections_Success(t *testing.T) {
+	t.Parallel()
+	repo := new(mockRepo)
+	now := time.Date(2026, 3, 20, 2, 10, 0, 0, time.UTC)
+	credential := testListCredential(12, "gmail", "User@Gmail.com", now.Add(-24*time.Hour))
+	unsupported := testListCredential(13, "outlook", "user@outlook.com", now.Add(-23*time.Hour))
+
+	repo.On("ListCredentialsByUser", mock.Anything, uint(1)).Return([]domain.EmailCredential{credential, unsupported}, nil)
+
+	uc := newTestUseCase(repo, new(mockOAuthCfg), nil, nil, testOSW(), testClock(now))
+	connections, err := uc.ListConnections(context.Background(), 1)
+
+	assert.NoError(t, err)
+	assert.Len(t, connections, 2)
+	assert.Equal(t, uint(12), connections[0].ID)
+	assert.Equal(t, "gmail", connections[0].Provider)
+	assert.Equal(t, "user@gmail.com", connections[0].AccountIdentifier)
+	assert.Equal(t, credential.CreatedAt, connections[0].CreatedAt)
+	assert.Equal(t, credential.UpdatedAt, connections[0].UpdatedAt)
+	assert.Equal(t, "outlook", connections[1].Provider)
+	assert.Equal(t, "user@outlook.com", connections[1].AccountIdentifier)
+	repo.AssertExpectations(t)
+}
+
+func TestListConnections_ListError(t *testing.T) {
+	t.Parallel()
+	repo := new(mockRepo)
+	now := time.Date(2026, 3, 20, 2, 15, 0, 0, time.UTC)
+	repo.On("ListCredentialsByUser", mock.Anything, uint(1)).Return(([]domain.EmailCredential)(nil), errors.New("db timeout"))
+
+	uc := newTestUseCase(repo, new(mockOAuthCfg), nil, nil, testOSW(), testClock(now))
+	connections, err := uc.ListConnections(context.Background(), 1)
+
+	assert.Nil(t, connections)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list credentials")
 	repo.AssertExpectations(t)
 }

--- a/internal/emailcredential/domain/connection_view.go
+++ b/internal/emailcredential/domain/connection_view.go
@@ -1,0 +1,12 @@
+package domain
+
+import "time"
+
+// ConnectionView is the provider-agnostic read model returned by the list API.
+type ConnectionView struct {
+	ID                uint      `json:"id"`
+	Provider          string    `json:"provider"`
+	AccountIdentifier string    `json:"account_identifier"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
+}

--- a/internal/emailcredential/infrastructure/repository.go
+++ b/internal/emailcredential/infrastructure/repository.go
@@ -131,6 +131,23 @@ func (r *Repository) FindCredentialByUserAndGmail(ctx context.Context, userID ui
 	return toDomainCredential(rec), nil
 }
 
+func (r *Repository) ListCredentialsByUser(ctx context.Context, userID uint) ([]domain.EmailCredential, error) {
+	var records []credentialRecord
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("created_at ASC, id ASC").
+		Find(&records).Error; err != nil {
+		logDBQueryFailed(r.log, "email_credentials", "list_by_user", err)
+		return nil, fmt.Errorf("failed to list credentials: %w", err)
+	}
+
+	credentials := make([]domain.EmailCredential, 0, len(records))
+	for _, record := range records {
+		credentials = append(credentials, toDomainCredential(record))
+	}
+	return credentials, nil
+}
+
 func (r *Repository) CreateCredential(ctx context.Context, cred domain.EmailCredential) error {
 	rec := toCredentialRecord(cred)
 	if err := r.db.WithContext(ctx).Create(&rec).Error; err != nil {
@@ -178,6 +195,7 @@ func toDomainCredential(rec credentialRecord) domain.EmailCredential {
 
 func toCredentialRecord(cred domain.EmailCredential) credentialRecord {
 	return credentialRecord{
+		ID:                 cred.ID,
 		UserID:             cred.UserID,
 		Type:               cred.Type,
 		GmailAddress:       cred.GmailAddress,

--- a/internal/emailcredential/infrastructure/repository_test.go
+++ b/internal/emailcredential/infrastructure/repository_test.go
@@ -216,3 +216,55 @@ func TestUpdateCredentialTokens(t *testing.T) {
 	assert.Equal(t, "new-access", updated.AccessToken)
 	assert.Equal(t, "new-refresh", updated.RefreshToken)
 }
+
+func TestListCredentialsByUser_FiltersAndOrders(t *testing.T) {
+	env := newRepoTestEnv(t)
+	defer env.clean()
+	ctx := context.Background()
+
+	older := env.nowUTC.Add(-2 * time.Hour)
+	newer := env.nowUTC.Add(-1 * time.Hour)
+
+	require.NoError(t, env.repo.CreateCredential(ctx, domain.EmailCredential{
+		UserID:             1,
+		Type:               "gmail",
+		GmailAddress:       "first@gmail.com",
+		KeyVersion:         1,
+		AccessToken:        "enc-1",
+		AccessTokenDigest:  "dig-1",
+		RefreshToken:       "refresh-1",
+		RefreshTokenDigest: "refresh-dig-1",
+		CreatedAt:          older,
+		UpdatedAt:          older,
+	}))
+	require.NoError(t, env.repo.CreateCredential(ctx, domain.EmailCredential{
+		UserID:             2,
+		Type:               "gmail",
+		GmailAddress:       "other-user@gmail.com",
+		KeyVersion:         1,
+		AccessToken:        "enc-2",
+		AccessTokenDigest:  "dig-2",
+		RefreshToken:       "refresh-2",
+		RefreshTokenDigest: "refresh-dig-2",
+		CreatedAt:          env.nowUTC,
+		UpdatedAt:          env.nowUTC,
+	}))
+	require.NoError(t, env.repo.CreateCredential(ctx, domain.EmailCredential{
+		UserID:             1,
+		Type:               "gmail",
+		GmailAddress:       "second@gmail.com",
+		KeyVersion:         1,
+		AccessToken:        "enc-3",
+		AccessTokenDigest:  "dig-3",
+		RefreshToken:       "refresh-3",
+		RefreshTokenDigest: "refresh-dig-3",
+		CreatedAt:          newer,
+		UpdatedAt:          newer,
+	}))
+
+	credentials, err := env.repo.ListCredentialsByUser(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, credentials, 2)
+	assert.Equal(t, "first@gmail.com", credentials[0].GmailAddress)
+	assert.Equal(t, "second@gmail.com", credentials[1].GmailAddress)
+}


### PR DESCRIPTION
# 概要
メールアカウント連携一覧を返却するAPI実装

## 変更内容の要約
- メールアカウント連携一覧を返却するAPI実装

## 動作確認
- [x] TODOコメントを削除しています。TODOコメントを残す場合は妥当な理由があることを説明済みです。
- [x] 動作確認を行いました。
- [x] ローカル環境で`task test`が成功しています。
- [x] CIが成功しています。

## その他
- 懸念点があれば
