### PR TITLE
#60 メール再送信のリクエスト回数制限を修正する

### DIFF
--- a/internal/auth/application/auth_usecase.go
+++ b/internal/auth/application/auth_usecase.go
@@ -70,6 +70,8 @@ type AuthRepository interface {
 	ConsumeTokenAndVerifyUser(ctx context.Context, tokenID uint, userID uint, consumedAt time.Time) (domain.User, error)
 	// GetLatestTokenForUser retrieves the latest token for a user
 	GetLatestTokenForUser(ctx context.Context, userID uint) (domain.EmailVerificationToken, error)
+	// UpdateVerificationEmailResendWindow records the fixed-window resend state after a successful resend.
+	UpdateVerificationEmailResendWindow(ctx context.Context, tokenID uint, windowStartedAt time.Time, resendCount int) error
 	// DeleteTokenByID deletes a token by ID
 	DeleteTokenByID(ctx context.Context, tokenID uint) error
 	// CreateRefreshToken stores a refresh token record.

--- a/internal/auth/application/auth_usecase_test.go
+++ b/internal/auth/application/auth_usecase_test.go
@@ -89,6 +89,11 @@ func (m *mockAuthRepository) DeleteTokenByID(ctx context.Context, tokenID uint) 
 	return args.Error(0)
 }
 
+func (m *mockAuthRepository) UpdateVerificationEmailResendWindow(ctx context.Context, tokenID uint, windowStartedAt time.Time, resendCount int) error {
+	args := m.Called(ctx, tokenID, windowStartedAt, resendCount)
+	return args.Error(0)
+}
+
 func (m *mockAuthRepository) CreateRefreshToken(ctx context.Context, token domain.RefreshToken) (domain.RefreshToken, error) {
 	args := m.Called(ctx, token)
 	refreshToken, _ := args.Get(0).(domain.RefreshToken)
@@ -555,6 +560,7 @@ func TestAuthUseCase_ResendVerificationEmailSuccess(t *testing.T) {
 	mailer.On("SendVerificationEmail", mock.Anything, mock.Anything, mock.MatchedBy(func(url string) bool {
 		return url == "https://example.com/signup/verify?token=new-token"
 	})).Return(nil).Once()
+	repo.On("UpdateVerificationEmailResendWindow", mock.Anything, uint(2), fixedTime, 1).Return(nil).Once()
 
 	stubOS := mocklibrary.NewOsWrapperMock(map[string]string{"FRONT_DOMAIN": "https://example.com"})
 	uc := NewAuthUseCase(repo, stubOS, mailer, &stubClock{now: fixedTime}, testVault())
@@ -662,11 +668,13 @@ func TestAuthUseCase_ResendVerificationEmailRateLimited(t *testing.T) {
 	}
 
 	recentToken := domain.EmailVerificationToken{
-		ID:        1,
-		UserID:    1,
-		Token:     "recent-token",
-		ExpiresAt: fixedTime.Add(1 * time.Hour),
-		CreatedAt: fixedTime.Add(-10 * time.Minute), // Less than 15 minutes ago
+		ID:                    1,
+		UserID:                1,
+		Token:                 "recent-token",
+		ExpiresAt:             fixedTime.Add(1 * time.Hour),
+		CreatedAt:             fixedTime.Add(-10 * time.Minute),
+		ResendWindowStartedAt: timePtr(fixedTime.Add(-10 * time.Minute)),
+		ResendCount:           3,
 	}
 
 	repo.On("GetUserByEmail", mock.Anything, domain.EmailAddress("user@example.com")).Return(user, nil).Once()
@@ -725,4 +733,183 @@ func TestAuthUseCase_ResendVerificationEmailMailSendFailed(t *testing.T) {
 	assert.ErrorIs(t, err, ErrMailSendFailed)
 	repo.AssertExpectations(t)
 	mailer.AssertExpectations(t)
+}
+
+func TestAuthUseCase_ResendVerificationEmail_AllowsImmediateResendAfterRegister(t *testing.T) {
+	t.Parallel()
+	fixedTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	repo := new(mockAuthRepository)
+	mailer := new(mockVerificationEmailSender)
+
+	hashed, err := testVault().GenerateHashPassword("password123")
+	assert.NoError(t, err)
+	hashedPassword := domain.NewPasswordHashFromHash(hashed)
+
+	user := domain.User{
+		ID:           1,
+		Email:        domain.EmailAddress("user@example.com"),
+		PasswordHash: hashedPassword,
+	}
+
+	registerToken := domain.EmailVerificationToken{
+		ID:        1,
+		UserID:    1,
+		Token:     "register-token",
+		ExpiresAt: fixedTime.Add(3 * time.Hour),
+		CreatedAt: fixedTime.Add(-1 * time.Minute),
+	}
+
+	repo.On("GetUserByEmail", mock.Anything, domain.EmailAddress("user@example.com")).Return(user, nil).Once()
+	repo.On("GetLatestTokenForUser", mock.Anything, uint(1)).Return(registerToken, nil).Once()
+	repo.On("GetActiveTokenForUser", mock.Anything, uint(1), fixedTime).Return(registerToken, nil).Once()
+	mailer.On("SendVerificationEmail", mock.Anything, mock.Anything, "https://example.com/signup/verify?token=register-token").Return(nil).Once()
+	repo.On("UpdateVerificationEmailResendWindow", mock.Anything, uint(1), fixedTime, 1).Return(nil).Once()
+
+	stubOS := mocklibrary.NewOsWrapperMock(map[string]string{"FRONT_DOMAIN": "https://example.com"})
+	uc := NewAuthUseCase(repo, stubOS, mailer, &stubClock{now: fixedTime}, testVault())
+
+	err = uc.ResendVerificationEmail(context.Background(), domain.ResendVerificationRequest{
+		Email:    "user@example.com",
+		Password: "password123",
+	})
+
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+	mailer.AssertExpectations(t)
+}
+
+func TestAuthUseCase_ResendVerificationEmailMailSendFailed_DoesNotDeleteExistingToken(t *testing.T) {
+	t.Parallel()
+	fixedTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	repo := new(mockAuthRepository)
+	mailer := new(mockVerificationEmailSender)
+
+	hashed, err := testVault().GenerateHashPassword("password123")
+	assert.NoError(t, err)
+	hashedPassword := domain.NewPasswordHashFromHash(hashed)
+
+	user := domain.User{
+		ID:           1,
+		Email:        domain.EmailAddress("user@example.com"),
+		PasswordHash: hashedPassword,
+	}
+
+	existingToken := domain.EmailVerificationToken{
+		ID:        1,
+		UserID:    1,
+		Token:     "existing-token",
+		ExpiresAt: fixedTime.Add(2 * time.Hour),
+		CreatedAt: fixedTime.Add(-2 * time.Hour),
+	}
+
+	repo.On("GetUserByEmail", mock.Anything, domain.EmailAddress("user@example.com")).Return(user, nil).Once()
+	repo.On("GetLatestTokenForUser", mock.Anything, uint(1)).Return(existingToken, nil).Once()
+	repo.On("GetActiveTokenForUser", mock.Anything, uint(1), fixedTime).Return(existingToken, nil).Once()
+	mailer.On("SendVerificationEmail", mock.Anything, mock.Anything, "https://example.com/signup/verify?token=existing-token").Return(errors.New("smtp error")).Once()
+
+	stubOS := mocklibrary.NewOsWrapperMock(map[string]string{"FRONT_DOMAIN": "https://example.com"})
+	uc := NewAuthUseCase(repo, stubOS, mailer, &stubClock{now: fixedTime}, testVault())
+
+	err = uc.ResendVerificationEmail(context.Background(), domain.ResendVerificationRequest{
+		Email:    "user@example.com",
+		Password: "password123",
+	})
+
+	assert.ErrorIs(t, err, ErrMailSendFailed)
+	repo.AssertExpectations(t)
+	mailer.AssertExpectations(t)
+}
+
+func TestAuthUseCase_ResendVerificationEmailWithinWindowIncrementsCount(t *testing.T) {
+	t.Parallel()
+	fixedTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	repo := new(mockAuthRepository)
+	mailer := new(mockVerificationEmailSender)
+
+	hashed, err := testVault().GenerateHashPassword("password123")
+	assert.NoError(t, err)
+	hashedPassword := domain.NewPasswordHashFromHash(hashed)
+
+	user := domain.User{
+		ID:           1,
+		Email:        domain.EmailAddress("user@example.com"),
+		PasswordHash: hashedPassword,
+	}
+
+	activeToken := domain.EmailVerificationToken{
+		ID:                    1,
+		UserID:                1,
+		Token:                 "active-token",
+		ExpiresAt:             fixedTime.Add(2 * time.Hour),
+		CreatedAt:             fixedTime.Add(-20 * time.Minute),
+		ResendWindowStartedAt: timePtr(fixedTime.Add(-10 * time.Minute)),
+		ResendCount:           2,
+	}
+
+	repo.On("GetUserByEmail", mock.Anything, domain.EmailAddress("user@example.com")).Return(user, nil).Once()
+	repo.On("GetLatestTokenForUser", mock.Anything, uint(1)).Return(activeToken, nil).Once()
+	repo.On("GetActiveTokenForUser", mock.Anything, uint(1), fixedTime).Return(activeToken, nil).Once()
+	mailer.On("SendVerificationEmail", mock.Anything, mock.Anything, "https://example.com/signup/verify?token=active-token").Return(nil).Once()
+	repo.On("UpdateVerificationEmailResendWindow", mock.Anything, uint(1), fixedTime.Add(-10*time.Minute), 3).Return(nil).Once()
+
+	stubOS := mocklibrary.NewOsWrapperMock(map[string]string{"FRONT_DOMAIN": "https://example.com"})
+	uc := NewAuthUseCase(repo, stubOS, mailer, &stubClock{now: fixedTime}, testVault())
+
+	err = uc.ResendVerificationEmail(context.Background(), domain.ResendVerificationRequest{
+		Email:    "user@example.com",
+		Password: "password123",
+	})
+
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+	mailer.AssertExpectations(t)
+}
+
+func TestAuthUseCase_ResendVerificationEmailExpiredWindowResetsCount(t *testing.T) {
+	t.Parallel()
+	fixedTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	repo := new(mockAuthRepository)
+	mailer := new(mockVerificationEmailSender)
+
+	hashed, err := testVault().GenerateHashPassword("password123")
+	assert.NoError(t, err)
+	hashedPassword := domain.NewPasswordHashFromHash(hashed)
+
+	user := domain.User{
+		ID:           1,
+		Email:        domain.EmailAddress("user@example.com"),
+		PasswordHash: hashedPassword,
+	}
+
+	activeToken := domain.EmailVerificationToken{
+		ID:                    1,
+		UserID:                1,
+		Token:                 "active-token",
+		ExpiresAt:             fixedTime.Add(2 * time.Hour),
+		CreatedAt:             fixedTime.Add(-2 * time.Hour),
+		ResendWindowStartedAt: timePtr(fixedTime.Add(-20 * time.Minute)),
+		ResendCount:           3,
+	}
+
+	repo.On("GetUserByEmail", mock.Anything, domain.EmailAddress("user@example.com")).Return(user, nil).Once()
+	repo.On("GetLatestTokenForUser", mock.Anything, uint(1)).Return(activeToken, nil).Once()
+	repo.On("GetActiveTokenForUser", mock.Anything, uint(1), fixedTime).Return(activeToken, nil).Once()
+	mailer.On("SendVerificationEmail", mock.Anything, mock.Anything, "https://example.com/signup/verify?token=active-token").Return(nil).Once()
+	repo.On("UpdateVerificationEmailResendWindow", mock.Anything, uint(1), fixedTime, 1).Return(nil).Once()
+
+	stubOS := mocklibrary.NewOsWrapperMock(map[string]string{"FRONT_DOMAIN": "https://example.com"})
+	uc := NewAuthUseCase(repo, stubOS, mailer, &stubClock{now: fixedTime}, testVault())
+
+	err = uc.ResendVerificationEmail(context.Background(), domain.ResendVerificationRequest{
+		Email:    "user@example.com",
+		Password: "password123",
+	})
+
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+	mailer.AssertExpectations(t)
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
 }

--- a/internal/auth/application/resend_verification_email.go
+++ b/internal/auth/application/resend_verification_email.go
@@ -12,8 +12,13 @@ import (
 	"gorm.io/gorm"
 )
 
-// ResendVerificationEmail resends the verification email after authenticating the user
-// and checking rate limits (15 minutes since last token).
+const (
+	resendVerificationWindow = 15 * time.Minute
+	maxResendCountPerWindow  = 3
+)
+
+// ResendVerificationEmail resends the verification email after authenticating the user.
+// The fixed window rate limit applies only to successful resend operations, not to the initial registration email.
 // It checks for an existing active token and reuses it if available.
 func (uc *AuthUseCase) ResendVerificationEmail(ctx context.Context, req domain.ResendVerificationRequest) error {
 	// Authenticate the user
@@ -46,16 +51,22 @@ func (uc *AuthUseCase) ResendVerificationEmail(ctx context.Context, req domain.R
 		return fmt.Errorf("failed to get latest token: %w", err)
 	}
 
-	if err == nil {
-		// Token exists, check rate limit
-		if now.Sub(latestToken.CreatedAt) < 15*time.Minute {
-			return ErrResendRateLimited
+	windowStartedAt := now
+	nextResendCount := 1
+	if err == nil && latestToken.ResendWindowStartedAt != nil {
+		if now.Sub(*latestToken.ResendWindowStartedAt) < resendVerificationWindow {
+			if latestToken.ResendCount >= maxResendCountPerWindow {
+				return ErrResendRateLimited
+			}
+			windowStartedAt = *latestToken.ResendWindowStartedAt
+			nextResendCount = latestToken.ResendCount + 1
 		}
 	}
 
 	// Check for existing active token
 	existingToken, err := uc.repo.GetActiveTokenForUser(ctx, user.ID, now)
 	var tokenToUse domain.EmailVerificationToken
+	createdNewToken := false
 
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return fmt.Errorf("failed to check existing token: %w", err)
@@ -79,6 +90,7 @@ func (uc *AuthUseCase) ResendVerificationEmail(ctx context.Context, req domain.R
 			return fmt.Errorf("failed to create verification token: %w", err)
 		}
 		tokenToUse = createdToken
+		createdNewToken = true
 	}
 
 	// Send verification email
@@ -92,9 +104,15 @@ func (uc *AuthUseCase) ResendVerificationEmail(ctx context.Context, req domain.R
 
 	err = uc.mailer.SendVerificationEmail(ctx, user, verifyURL)
 	if err != nil {
-		// Delete the token if email sending fails
-		_ = uc.repo.DeleteTokenByID(ctx, tokenToUse.ID)
+		// Roll back only tokens created by this resend attempt.
+		if createdNewToken {
+			_ = uc.repo.DeleteTokenByID(ctx, tokenToUse.ID)
+		}
 		return ErrMailSendFailed
+	}
+
+	if err := uc.repo.UpdateVerificationEmailResendWindow(ctx, tokenToUse.ID, windowStartedAt, nextResendCount); err != nil {
+		return fmt.Errorf("failed to update resend window: %w", err)
 	}
 
 	return nil

--- a/internal/auth/domain/email_verification_token.go
+++ b/internal/auth/domain/email_verification_token.go
@@ -4,10 +4,12 @@ import "time"
 
 // EmailVerificationToken represents the email verification token entity
 type EmailVerificationToken struct {
-	ID         uint
-	UserID     uint
-	Token      string
-	ExpiresAt  time.Time
-	CreatedAt  time.Time
-	ConsumedAt *time.Time
+	ID                    uint
+	UserID                uint
+	Token                 string
+	ExpiresAt             time.Time
+	CreatedAt             time.Time
+	ResendWindowStartedAt *time.Time
+	ResendCount           int
+	ConsumedAt            *time.Time
 }

--- a/internal/auth/infrastructure/repository.go
+++ b/internal/auth/infrastructure/repository.go
@@ -58,12 +58,14 @@ func (userRecord) TableName() string {
 
 // emailVerificationTokenRecord represents the database record structure for email_verification_tokens table
 type emailVerificationTokenRecord struct {
-	ID         uint       `gorm:"column:id"`
-	UserID     uint       `gorm:"column:user_id"`
-	Token      string     `gorm:"column:token;unique"`
-	ExpiresAt  time.Time  `gorm:"column:expires_at"`
-	CreatedAt  time.Time  `gorm:"column:created_at"`
-	ConsumedAt *time.Time `gorm:"column:consumed_at"`
+	ID                    uint       `gorm:"column:id"`
+	UserID                uint       `gorm:"column:user_id"`
+	Token                 string     `gorm:"column:token;unique"`
+	ExpiresAt             time.Time  `gorm:"column:expires_at"`
+	CreatedAt             time.Time  `gorm:"column:created_at"`
+	ResendWindowStartedAt *time.Time `gorm:"column:resend_window_started_at"`
+	ResendCount           int        `gorm:"column:resend_count"`
+	ConsumedAt            *time.Time `gorm:"column:consumed_at"`
 }
 
 // TableName specifies the table name for emailVerificationTokenRecord

--- a/internal/auth/infrastructure/repository_tokens.go
+++ b/internal/auth/infrastructure/repository_tokens.go
@@ -44,12 +44,14 @@ func (r *Repository) GetActiveTokenForUser(ctx context.Context, userID uint, now
 	}
 
 	return domain.EmailVerificationToken{
-		ID:         record.ID,
-		UserID:     record.UserID,
-		Token:      record.Token,
-		ExpiresAt:  record.ExpiresAt,
-		CreatedAt:  record.CreatedAt,
-		ConsumedAt: record.ConsumedAt,
+		ID:                    record.ID,
+		UserID:                record.UserID,
+		Token:                 record.Token,
+		ExpiresAt:             record.ExpiresAt,
+		CreatedAt:             record.CreatedAt,
+		ResendWindowStartedAt: record.ResendWindowStartedAt,
+		ResendCount:           record.ResendCount,
+		ConsumedAt:            record.ConsumedAt,
 	}, nil
 }
 
@@ -66,11 +68,13 @@ func (r *Repository) CreateEmailVerificationToken(ctx context.Context, token dom
 	}
 
 	record := emailVerificationTokenRecord{
-		UserID:     token.UserID,
-		Token:      token.Token,
-		ExpiresAt:  token.ExpiresAt,
-		CreatedAt:  token.CreatedAt,
-		ConsumedAt: token.ConsumedAt,
+		UserID:                token.UserID,
+		Token:                 token.Token,
+		ExpiresAt:             token.ExpiresAt,
+		CreatedAt:             token.CreatedAt,
+		ResendWindowStartedAt: token.ResendWindowStartedAt,
+		ResendCount:           token.ResendCount,
+		ConsumedAt:            token.ConsumedAt,
 	}
 
 	// Use Clauses(clause.OnConflict) for upsert behavior on user_id unique constraint
@@ -78,10 +82,12 @@ func (r *Repository) CreateEmailVerificationToken(ctx context.Context, token dom
 		Clauses(clause.OnConflict{
 			Columns: []clause.Column{{Name: "user_id"}},
 			DoUpdates: clause.Assignments(map[string]interface{}{
-				"token":       record.Token,
-				"expires_at":  record.ExpiresAt,
-				"created_at":  record.CreatedAt,
-				"consumed_at": record.ConsumedAt,
+				"token":                    record.Token,
+				"expires_at":               record.ExpiresAt,
+				"created_at":               record.CreatedAt,
+				"resend_window_started_at": record.ResendWindowStartedAt,
+				"resend_count":             record.ResendCount,
+				"consumed_at":              record.ConsumedAt,
 			}),
 		}).
 		Create(&record).
@@ -104,12 +110,14 @@ func (r *Repository) CreateEmailVerificationToken(ctx context.Context, token dom
 	}
 
 	return domain.EmailVerificationToken{
-		ID:         record.ID,
-		UserID:     record.UserID,
-		Token:      record.Token,
-		ExpiresAt:  record.ExpiresAt,
-		CreatedAt:  record.CreatedAt,
-		ConsumedAt: record.ConsumedAt,
+		ID:                    record.ID,
+		UserID:                record.UserID,
+		Token:                 record.Token,
+		ExpiresAt:             record.ExpiresAt,
+		CreatedAt:             record.CreatedAt,
+		ResendWindowStartedAt: record.ResendWindowStartedAt,
+		ResendCount:           record.ResendCount,
+		ConsumedAt:            record.ConsumedAt,
 	}, nil
 }
 
@@ -165,12 +173,14 @@ func (r *Repository) GetEmailVerificationToken(ctx context.Context, token string
 	}
 
 	return domain.EmailVerificationToken{
-		ID:         record.ID,
-		UserID:     record.UserID,
-		Token:      record.Token,
-		ExpiresAt:  record.ExpiresAt,
-		CreatedAt:  record.CreatedAt,
-		ConsumedAt: record.ConsumedAt,
+		ID:                    record.ID,
+		UserID:                record.UserID,
+		Token:                 record.Token,
+		ExpiresAt:             record.ExpiresAt,
+		CreatedAt:             record.CreatedAt,
+		ResendWindowStartedAt: record.ResendWindowStartedAt,
+		ResendCount:           record.ResendCount,
+		ConsumedAt:            record.ConsumedAt,
 	}, nil
 }
 
@@ -280,13 +290,43 @@ func (r *Repository) GetLatestTokenForUser(ctx context.Context, userID uint) (do
 	}
 
 	return domain.EmailVerificationToken{
-		ID:         record.ID,
-		UserID:     record.UserID,
-		Token:      record.Token,
-		ExpiresAt:  record.ExpiresAt,
-		CreatedAt:  record.CreatedAt,
-		ConsumedAt: record.ConsumedAt,
+		ID:                    record.ID,
+		UserID:                record.UserID,
+		Token:                 record.Token,
+		ExpiresAt:             record.ExpiresAt,
+		CreatedAt:             record.CreatedAt,
+		ResendWindowStartedAt: record.ResendWindowStartedAt,
+		ResendCount:           record.ResendCount,
+		ConsumedAt:            record.ConsumedAt,
 	}, nil
+}
+
+// UpdateVerificationEmailResendWindow updates the fixed-window resend state for a token.
+func (r *Repository) UpdateVerificationEmailResendWindow(ctx context.Context, tokenID uint, windowStartedAt time.Time, resendCount int) error {
+	if ctx == nil {
+		return logger.ErrNilContext
+	}
+
+	reqLog, logErr := r.logger.WithContext(ctx)
+	if logErr != nil {
+		return logErr
+	}
+
+	err := r.db.WithContext(ctx).
+		Model(&emailVerificationTokenRecord{}).
+		Where("id = ?", tokenID).
+		Updates(map[string]interface{}{
+			"resend_window_started_at": windowStartedAt,
+			"resend_count":             resendCount,
+		}).
+		Error
+
+	if err != nil {
+		logDBQueryFailed(reqLog, "email_verification_tokens", "update_verification_email_resend_window", err, logger.Uint("token_id", tokenID))
+		return fmt.Errorf("failed to update verification email resend window: %w", err)
+	}
+
+	return nil
 }
 
 // DeleteTokenByID deletes a token by ID.

--- a/internal/auth/infrastructure/token_repository_test.go
+++ b/internal/auth/infrastructure/token_repository_test.go
@@ -38,6 +38,8 @@ func TestRepository_CreateEmailVerificationToken_Success(t *testing.T) {
 	assert.Equal(t, userRec.ID, created.UserID)
 	assert.Equal(t, "test-token-uuid", created.Token)
 	assert.WithinDuration(t, expiresAt, created.ExpiresAt, time.Second)
+	assert.Nil(t, created.ResendWindowStartedAt)
+	assert.Zero(t, created.ResendCount)
 }
 
 func TestRepository_InvalidateActiveTokens_Success(t *testing.T) {
@@ -207,10 +209,12 @@ func TestRepository_GetLatestTokenForUser_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	err = env.db.Create(&emailVerificationTokenRecord{
-		UserID:    userRec.ID,
-		Token:     "latest-token",
-		ExpiresAt: env.nowUTC.Add(3 * time.Hour),
-		CreatedAt: env.nowUTC,
+		UserID:                userRec.ID,
+		Token:                 "latest-token",
+		ExpiresAt:             env.nowUTC.Add(3 * time.Hour),
+		CreatedAt:             env.nowUTC,
+		ResendWindowStartedAt: timePtr(env.nowUTC.Add(-5 * time.Minute)),
+		ResendCount:           2,
 	}).Error
 	require.NoError(t, err)
 
@@ -219,6 +223,9 @@ func TestRepository_GetLatestTokenForUser_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "latest-token", token.Token)
 	assert.WithinDuration(t, env.nowUTC, token.CreatedAt, time.Second)
+	require.NotNil(t, token.ResendWindowStartedAt)
+	assert.WithinDuration(t, env.nowUTC.Add(-5*time.Minute), *token.ResendWindowStartedAt, time.Second)
+	assert.Equal(t, 2, token.ResendCount)
 }
 
 func TestRepository_GetLatestTokenForUser_NotFound(t *testing.T) {
@@ -262,6 +269,39 @@ func TestRepository_DeleteTokenByID_Success(t *testing.T) {
 	assert.Equal(t, int64(0), count)
 }
 
+func TestRepository_UpdateVerificationEmailResendWindow_Success(t *testing.T) {
+	t.Parallel()
+	env := newAuthRepoTestEnv(t)
+	defer func() { _ = env.clean() }()
+
+	env.insertUser(t, "resent@example.com")
+	var userRec userRecord
+	err := env.db.Where("email = ?", "resent@example.com").First(&userRec).Error
+	require.NoError(t, err)
+
+	var tokenRec emailVerificationTokenRecord
+	err = env.db.Create(&emailVerificationTokenRecord{
+		UserID:    userRec.ID,
+		Token:     "resent-token",
+		ExpiresAt: env.nowUTC.Add(3 * time.Hour),
+		CreatedAt: env.nowUTC,
+	}).Error
+	require.NoError(t, err)
+	err = env.db.Where("token = ?", "resent-token").First(&tokenRec).Error
+	require.NoError(t, err)
+
+	windowStartedAt := env.nowUTC.Add(5 * time.Minute)
+	err = env.repo.UpdateVerificationEmailResendWindow(context.Background(), tokenRec.ID, windowStartedAt, 2)
+	require.NoError(t, err)
+
+	var updatedToken emailVerificationTokenRecord
+	err = env.db.Where("id = ?", tokenRec.ID).First(&updatedToken).Error
+	require.NoError(t, err)
+	require.NotNil(t, updatedToken.ResendWindowStartedAt)
+	assert.WithinDuration(t, windowStartedAt, *updatedToken.ResendWindowStartedAt, time.Second)
+	assert.Equal(t, 2, updatedToken.ResendCount)
+}
+
 func TestRepository_GetActiveTokenForUser_Success(t *testing.T) {
 	t.Parallel()
 	env := newAuthRepoTestEnv(t)
@@ -275,10 +315,12 @@ func TestRepository_GetActiveTokenForUser_Success(t *testing.T) {
 	// Create an active token
 	expiresAt := env.nowUTC.Add(3 * time.Hour)
 	err = env.db.Create(&emailVerificationTokenRecord{
-		UserID:    userRec.ID,
-		Token:     "active-token",
-		ExpiresAt: expiresAt,
-		CreatedAt: env.nowUTC,
+		UserID:                userRec.ID,
+		Token:                 "active-token",
+		ExpiresAt:             expiresAt,
+		CreatedAt:             env.nowUTC,
+		ResendWindowStartedAt: timePtr(env.nowUTC.Add(-3 * time.Minute)),
+		ResendCount:           1,
 	}).Error
 	require.NoError(t, err)
 
@@ -287,6 +329,9 @@ func TestRepository_GetActiveTokenForUser_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "active-token", token.Token)
 	assert.Equal(t, userRec.ID, token.UserID)
+	require.NotNil(t, token.ResendWindowStartedAt)
+	assert.WithinDuration(t, env.nowUTC.Add(-3*time.Minute), *token.ResendWindowStartedAt, time.Second)
+	assert.Equal(t, 1, token.ResendCount)
 	assert.Nil(t, token.ConsumedAt)
 }
 
@@ -323,6 +368,10 @@ func TestRepository_GetActiveTokenForUser_ExpiredToken(t *testing.T) {
 	_, err = env.repo.GetActiveTokenForUser(context.Background(), userRec.ID, env.nowUTC)
 
 	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
 }
 
 func TestRepository_GetActiveTokenForUser_ConsumedToken(t *testing.T) {

--- a/tools/migrations/ddl/20260328120000_add_email_verification_token_resend_window.sql
+++ b/tools/migrations/ddl/20260328120000_add_email_verification_token_resend_window.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `email_verification_tokens`
+  ADD COLUMN `resend_window_started_at` datetime(3) NULL AFTER `created_at`,
+  ADD COLUMN `resend_count` int unsigned NOT NULL DEFAULT 0 AFTER `resend_window_started_at`;

--- a/tools/migrations/ddl/atlas.sum
+++ b/tools/migrations/ddl/atlas.sum
@@ -1,4 +1,4 @@
-h1:aK+gKo64Rqw4sqxpkoig7u+WYRud8t/P+PKrXtZZMXU=
+h1:02a7yer+lkzfRnFbD/gl1QmtZ7m2TvNSzk+lsHIIczo=
 20260202104821.sql h1:Fj9N9Redpan5s89RVJdyJ84em5ik/m0wLmYJ9zdAvD0=
 20260319000000.sql h1:kmOfWLJVYbNClLOTiiCg/dAB/xQbK+LWlUDUE6urtd4=
 20260319100000.sql h1:KOhZwpsgeIJw1tP293SJxxm3y46RYtRHc/jePidaH50=
@@ -13,3 +13,4 @@ h1:aK+gKo64Rqw4sqxpkoig7u+WYRud8t/P+PKrXtZZMXU=
 20260326153000.sql h1:QWdQBEChhXKkyMEObmQWjgWiMm7bXz5OXiwRJulK5Iw=
 20260326170000.sql h1:3+MFKeP6DZ03TQnS33dVb3JTQWukQjgaa90N5dvhSAo=
 20260327011806_add_vendor_user_scope.sql h1:SEkTc+zZUdDhcoC22b0rk3Uw2ENK3EDmU5nbKTYdhW0=
+20260328120000_add_email_verification_token_resend_window.sql h1:QJYSmYFdnNUmVFqcvOLWpM6NE0bKR7sJWm7BRg3T92w=

--- a/tools/migrations/models/email_verification_token.go
+++ b/tools/migrations/models/email_verification_token.go
@@ -4,12 +4,14 @@ import "time"
 
 // EmailVerificationToken represents the email_verification_tokens table
 type EmailVerificationToken struct {
-	ID         uint      `gorm:"primaryKey;autoIncrement"`
-	UserID     uint      `gorm:"not null;uniqueIndex:idx_user_id_unique"`
-	Token      string    `gorm:"size:36;unique;not null;index:idx_token"`
-	ExpiresAt  time.Time `gorm:"not null"`
-	CreatedAt  time.Time `gorm:"not null"`
-	ConsumedAt *time.Time
+	ID                    uint      `gorm:"primaryKey;autoIncrement"`
+	UserID                uint      `gorm:"not null;uniqueIndex:idx_user_id_unique"`
+	Token                 string    `gorm:"size:36;unique;not null;index:idx_token"`
+	ExpiresAt             time.Time `gorm:"not null"`
+	CreatedAt             time.Time `gorm:"not null"`
+	ResendWindowStartedAt *time.Time
+	ResendCount           int `gorm:"not null;default:0"`
+	ConsumedAt            *time.Time
 }
 
 // TableName specifies the table name for the EmailVerificationToken model


### PR DESCRIPTION
# 概要
メール再送信のリクエスト回数制限を修正する

## 変更内容の要約
- メール再送信のリクエスト回数制限を修正

## 動作確認
- [x] TODOコメントを削除しています。TODOコメントを残す場合は妥当な理由があることを説明済みです。
- [x] 動作確認を行いました。
- [x] ローカル環境で`task test`が成功しています。
- [x] CIが成功しています。

## その他
- 懸念点があれば
