### PR TITLE
#71 手動実行履歴テーブルの解析結果数を集計して返却するAPIを実装する

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -7,7 +7,7 @@
 | [Billing 一覧 API](./BillingList.md) | `GET` | `/api/v1/billings` | 認証済みユーザー自身の請求一覧を、検索中心で取得する。 |
 | [Billing Monthly Trend API](./BillingMonthlyTrend.md) | `GET` | `/api/v1/billings/summary/monthly-trend` | 認証済みユーザー自身の請求を、通貨別の直近 12 ヶ月 zero-fill 推移として取得する。 |
 | [Billing Month Detail API](./BillingMonthDetail.md) | `GET` | `/api/v1/billings/summary/monthly-detail/:year_month` | 認証済みユーザー自身の請求を、指定月の支払先別内訳付き詳細として取得する。 |
-| [Dashboard Summary API](./dashboardSummary/requirementsDefinition.md) | `GET` | `/api/v1/dashboard/summary` | 認証済みユーザー自身のダッシュボード KPI を取得する。 |
+| [ダッシュボード 解析・保存サマリー](./dashboardSummary/requirementsDefinition.md) | `GET` | `/api/v1/dashboard/summary` | 認証済みユーザー自身のダッシュボード KPI を取得する。 |
 | [Gmail OAuth 認可 URL 発行 API](./MailAccountConnection.md) | `POST` | `/api/v1/mail-account-connections/gmail/authorize` | 認証済みユーザー向けに Gmail OAuth の認可 URL と有効期限を発行する。 |
 | [Gmail OAuth コールバック受付 API](./MailAccountConnection.md) | `POST` | `/api/v1/mail-account-connections/gmail/callback` | frontend から受け取った `code` と `state` を検証し、MailAccountConnection を作成または再連携する。 |
 | [MailAccountConnection 一覧 API](./MailAccountConnectionList.md) | `GET` | `/api/v1/mail-account-connections` | 認証済みユーザー自身のメール連携一覧を返す。provider へのリアルタイム確認は行わない。 |

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -7,6 +7,7 @@
 | [Billing 一覧 API](./BillingList.md) | `GET` | `/api/v1/billings` | 認証済みユーザー自身の請求一覧を、検索中心で取得する。 |
 | [Billing Monthly Trend API](./BillingMonthlyTrend.md) | `GET` | `/api/v1/billings/summary/monthly-trend` | 認証済みユーザー自身の請求を、通貨別の直近 12 ヶ月 zero-fill 推移として取得する。 |
 | [Billing Month Detail API](./BillingMonthDetail.md) | `GET` | `/api/v1/billings/summary/monthly-detail/:year_month` | 認証済みユーザー自身の請求を、指定月の支払先別内訳付き詳細として取得する。 |
+| [Dashboard Summary API](./dashboardSummary/requirementsDefinition.md) | `GET` | `/api/v1/dashboard/summary` | 認証済みユーザー自身のダッシュボード KPI を取得する。 |
 | [Gmail OAuth 認可 URL 発行 API](./MailAccountConnection.md) | `POST` | `/api/v1/mail-account-connections/gmail/authorize` | 認証済みユーザー向けに Gmail OAuth の認可 URL と有効期限を発行する。 |
 | [Gmail OAuth コールバック受付 API](./MailAccountConnection.md) | `POST` | `/api/v1/mail-account-connections/gmail/callback` | frontend から受け取った `code` と `state` を検証し、MailAccountConnection を作成または再連携する。 |
 | [MailAccountConnection 一覧 API](./MailAccountConnectionList.md) | `GET` | `/api/v1/mail-account-connections` | 認証済みユーザー自身のメール連携一覧を返す。provider へのリアルタイム確認は行わない。 |

--- a/docs/spec/dashboardSummary/design.md
+++ b/docs/spec/dashboardSummary/design.md
@@ -1,0 +1,141 @@
+# Dashboard Summary API 設計
+
+## 本書の位置づけ
+
+- 本書は `Dashboard Summary API` の基本設計をまとめる。
+- 要件定義は [requirementsDefinition.md](./requirementsDefinition.md) を参照する。
+- 本書では責務分割、API 契約、集計方針までを扱い、実装レベルの詳細は含めない。
+
+## 設計方針
+
+- `Dashboard Summary API` はダッシュボード初期表示専用の read API とする。
+- 3 指標は `parsed_emails` と `billings` にまたがるため、既存 `billings/summary` とは分離する。
+- 集計は domain で扱わず、repository で SQL 集計する。
+- application は「現在月の境界決定」と「複数集計結果の取りまとめ」に責務を限定する。
+- レスポンスは KPI 3 項目のみとし、内訳や推移は含めない。
+
+## 全体構成
+
+```mermaid
+flowchart TB
+  subgraph Presentation
+    CONTROLLER[dashboard Controller]
+  end
+
+  subgraph Query["internal/dashboardquery"]
+    USECASE[Summary UseCase]
+    REPOSITORY[Summary Repository]
+  end
+
+  subgraph DataStores
+    PARSED[parsed_emails]
+    BILLINGS[billings]
+  end
+
+  CONTROLLER --> USECASE
+  USECASE --> REPOSITORY
+  REPOSITORY --> PARSED
+  REPOSITORY --> BILLINGS
+```
+
+## API 契約
+
+### Endpoint
+- Method: `GET`
+- Path: `/api/v1/dashboard/summary`
+- Auth: required
+
+### Query
+- v1 では query parameter を持たない
+
+### Response 200
+```json
+{
+  "current_month_analysis_success_count": 1280,
+  "total_saved_billing_count": 842,
+  "fallback_billing_count": 73
+}
+```
+
+### Error
+- `401 unauthorized`
+  - JWT 不正または未認証
+- `500 internal_server_error`
+  - 集計取得の内部失敗
+
+## 責務分割
+
+| 対象 | 役割 | やらないこと |
+| --- | --- | --- |
+| `internal/app/presentation/dashboard` | HTTP 入力の受け取り、認証済み user の引き渡し、response への変換 | SQL 集計、月境界計算、domain 判定 |
+| `internal/dashboardquery/application` | UTC 現在月の境界決定、repository 呼び出し、KPI の取りまとめ | HTTP 依存、DB 直接操作 |
+| `internal/dashboardquery/infrastructure` | `parsed_emails` / `billings` を SQL 集計して返す | HTTP 依存、業務 aggregate の意味変更 |
+| `internal/common/domain` など既存 domain | 既存 aggregate / value object の保持 | dashboard KPI の新規業務概念化 |
+
+## 指標ごとの取得方針
+
+### `current_month_analysis_success_count`
+- 集計元は `parsed_emails` とする。
+- 月判定は v1 では UTC 現在月を使う。
+- application で「当月 UTC 月初」と「翌月 UTC 月初」を求め、その範囲で repository が件数集計する。
+- workflow 履歴の `analysis_success_count` 合算は使わない。
+
+### `total_saved_billing_count`
+- 集計元は `billings` とする。
+- 重複判定で保存されなかったものは含めない。
+- repository が保存済み請求件数を集計する。
+
+### `fallback_billing_count`
+- 集計元は `billings` とする。
+- 判定条件は `billing_date IS NULL` とする。
+- 既存 `fallback_billing_count` の意味と揃える。
+
+## SQL 集計方針
+
+- 件数集計は repository の SQL で行う。
+- domain に件数ロジックを持ち込まない。
+- 全件ロードして application で数える方式は採らない。
+- クエリ本数は固定とし、N+1 を起こさない。
+
+補足:
+- `current_month_analysis_success_count` は期間条件付き `COUNT(*)`
+- `total_saved_billing_count` は `billings` の `COUNT(*)`
+- `fallback_billing_count` は `billings.billing_date IS NULL` 条件付き `COUNT(*)`
+
+## package 構成
+
+```text
+internal/
+  app/
+    presentation/
+      dashboard/
+    router/
+  dashboardquery/
+    application/
+    infrastructure/
+  di/
+```
+
+## 基本設計上の判断
+
+- dashboard KPI は画面専用 read model として追加し、既存 aggregate の意味を変更しない。
+- 集計の正本は既存永続化データとし、workflow 履歴を現在値 API の集計元にはしない。
+- `billings` 由来の 2 指標について、「実件数と一致」は定義上の意味であり、別の同期処理や検証処理を追加する要求ではない。
+- 将来 KPI が増えても、同じ read API 内で追加できる余地を残す。
+
+## テスト観点
+
+### Controller
+- 200 正常系
+- 401 unauthorized
+- 500 internal_server_error
+
+### UseCase
+- UTC 月境界の既定値適用
+- データなし時に `0` を返す
+
+### Repository
+- `user_id` 所有範囲
+- `parsed_emails` 当月件数集計
+- `billings` 総件数集計
+- `billings.billing_date IS NULL` 件数集計

--- a/docs/spec/dashboardSummary/design.md
+++ b/docs/spec/dashboardSummary/design.md
@@ -53,7 +53,7 @@ flowchart TB
 {
   "current_month_analysis_success_count": 1280,
   "total_saved_billing_count": 842,
-  "fallback_billing_count": 73
+  "current_month_fallback_billing_count": 73
 }
 ```
 
@@ -85,10 +85,11 @@ flowchart TB
 - 重複判定で保存されなかったものは含めない。
 - repository が保存済み請求件数を集計する。
 
-### `fallback_billing_count`
+### `current_month_fallback_billing_count`
 - 集計元は `billings` とする。
 - 判定条件は `billing_date IS NULL` とする。
-- 既存 `fallback_billing_count` の意味と揃える。
+- 月判定は v1 では UTC 現在月を使う。
+- `billing_summary_date` で当月範囲に入るものを集計する。
 
 ## SQL 集計方針
 
@@ -100,7 +101,7 @@ flowchart TB
 補足:
 - `current_month_analysis_success_count` は期間条件付き `COUNT(*)`
 - `total_saved_billing_count` は `billings` の `COUNT(*)`
-- `fallback_billing_count` は `billings.billing_date IS NULL` 条件付き `COUNT(*)`
+- `current_month_fallback_billing_count` は `billings.billing_date IS NULL` かつ `billings.billing_summary_date` が当月範囲内の条件付き `COUNT(*)`
 
 ## package 構成
 
@@ -138,4 +139,4 @@ internal/
 - `user_id` 所有範囲
 - `parsed_emails` 当月件数集計
 - `billings` 総件数集計
-- `billings.billing_date IS NULL` 件数集計
+- `billings.billing_date IS NULL` かつ `billing_summary_date` 当月件数集計

--- a/docs/spec/dashboardSummary/requirementsDefinition.md
+++ b/docs/spec/dashboardSummary/requirementsDefinition.md
@@ -8,7 +8,7 @@
 ## 背景
 
 - 既存実装では `GET /api/v1/billings` と `GET /api/v1/billings/summary/*` により、請求一覧と請求サマリは取得できる。
-- 一方でダッシュボード初期表示では、一覧や月次明細ではなく「今月の解析成功件数」「累計保存請求件数」「補完件数」を軽く表示したい。
+- 一方でダッシュボード初期表示では、一覧や月次明細ではなく「今月の解析成功件数」「累計保存請求件数」「今月の補完件数」を軽く表示したい。
 - 今回必要な 3 指標は `parsed_emails` と `billings` にまたがるため、既存 `billings/summary` にそのまま寄せると責務がぶれやすい。
 - DDD 上でも、これら 3 指標を 1 つの業務集約としては定義していないため、新しい aggregate 追加ではなく画面専用の read API として扱う。
 
@@ -16,7 +16,7 @@
 
 - ダッシュボード初期表示のために、複数 API を組み合わせずに KPI を一括取得したい。
 - 解析成功件数は workflow 監査集計ではなく、現在値に近い保存済み解析結果ベースで取得したい。
-- 請求総件数と補完件数は、既存 `billings` の保存結果と意味がずれない形で取得したい。
+- 請求総件数と今月の補完件数は、既存 `billings` の保存結果と意味がずれない形で取得したい。
 
 ## 目標
 
@@ -24,7 +24,7 @@
 - v1 では次の 3 指標を返せるようにする。
   - `current_month_analysis_success_count`
   - `total_saved_billing_count`
-  - `fallback_billing_count`
+  - `current_month_fallback_billing_count`
 - フロントのモックを追加変換なしでそのまま描画できる shape にする。
 
 ## 対象範囲
@@ -52,13 +52,13 @@
   - レスポンスは少なくとも以下 3 項目を返せる。
     - `current_month_analysis_success_count`
     - `total_saved_billing_count`
-    - `fallback_billing_count`
+    - `current_month_fallback_billing_count`
 - `FR-4`
   - `current_month_analysis_success_count` は「当月に解析ステージで成功し、保存された件数」を意味する。
 - `FR-5`
   - `total_saved_billing_count` は「これまでに請求として実際に保存された総件数」を意味する。
 - `FR-6`
-  - `fallback_billing_count` は「これまでに請求として実際に保存されたデータのうち、`billing_date` がなく、メール受信日 fallback で判定した総件数」を意味する。
+  - `current_month_fallback_billing_count` は「当月に請求として扱われる保存済みデータのうち、`billing_date` がなく、メール受信日 fallback で判定した件数」を意味する。
 - `FR-7`
   - データが存在しない場合でも `200 OK` を返し、各項目は `0` を返せる。
 
@@ -84,9 +84,10 @@
 ## 制約・前提
 
 - `current_month_analysis_success_count` は workflow 履歴 header の合算ではなく、保存済み解析結果を基準に扱う。
-- `total_saved_billing_count` と `fallback_billing_count` は `billings` を基準に扱う。
-- `fallback_billing_count` の判定条件は既存 `fallback_billing_count` と同様に `billings.billing_date IS NULL` を基準にする。
-- `total_saved_billing_count` と `fallback_billing_count` の「実件数と一致」は、値の定義と集計元の意味を示すものであり、別途 reconcile 用の検証処理や同期処理を要求するものではない。
+- `total_saved_billing_count` と `current_month_fallback_billing_count` は `billings` を基準に扱う。
+- `current_month_fallback_billing_count` の判定条件は `billings.billing_date IS NULL` を基準にする。
+- `current_month_fallback_billing_count` の月判定は `billings.billing_summary_date` を使い、UTC 当月範囲で集計する。
+- `total_saved_billing_count` と `current_month_fallback_billing_count` の「実件数と一致」は、値の定義と集計元の意味を示すものであり、別途 reconcile 用の検証処理や同期処理を要求するものではない。
 
 ## 成功条件
 
@@ -94,5 +95,5 @@
 - フロントのモックを追加変換なしでそのまま描画できる。
 - `current_month_analysis_success_count` が保存済み解析結果ベースの件数として説明できる。
 - `total_saved_billing_count` が保存済み請求件数の意味で解釈できる。
-- `fallback_billing_count` が `billing_date` fallback 件数の意味で解釈できる。
+- `current_month_fallback_billing_count` が当月の `billing_date` fallback 件数の意味で解釈できる。
 - データ未作成ユーザーでも response shape が崩れず、`0` / `0` / `0` を返せる。

--- a/docs/spec/dashboardSummary/requirementsDefinition.md
+++ b/docs/spec/dashboardSummary/requirementsDefinition.md
@@ -1,0 +1,98 @@
+# Dashboard Summary API 要件定義
+
+## 本書の位置づけ
+
+- 本書は `Dashboard Summary API` の To-Be 要件を整理する。
+- 基本設計は [design.md](./design.md) を参照する。
+
+## 背景
+
+- 既存実装では `GET /api/v1/billings` と `GET /api/v1/billings/summary/*` により、請求一覧と請求サマリは取得できる。
+- 一方でダッシュボード初期表示では、一覧や月次明細ではなく「今月の解析成功件数」「累計保存請求件数」「補完件数」を軽く表示したい。
+- 今回必要な 3 指標は `parsed_emails` と `billings` にまたがるため、既存 `billings/summary` にそのまま寄せると責務がぶれやすい。
+- DDD 上でも、これら 3 指標を 1 つの業務集約としては定義していないため、新しい aggregate 追加ではなく画面専用の read API として扱う。
+
+## 解決したい課題
+
+- ダッシュボード初期表示のために、複数 API を組み合わせずに KPI を一括取得したい。
+- 解析成功件数は workflow 監査集計ではなく、現在値に近い保存済み解析結果ベースで取得したい。
+- 請求総件数と補完件数は、既存 `billings` の保存結果と意味がずれない形で取得したい。
+
+## 目標
+
+- `GET /api/v1/dashboard/summary` で、認証済みユーザー自身の KPI を取得できるようにする。
+- v1 では次の 3 指標を返せるようにする。
+  - `current_month_analysis_success_count`
+  - `total_saved_billing_count`
+  - `fallback_billing_count`
+- フロントのモックを追加変換なしでそのまま描画できる shape にする。
+
+## 対象範囲
+
+- ダッシュボード KPI 取得 API の責務定義
+- 3 指標の意味と集計元の定義
+- 月境界と所有範囲の扱い
+- read API としての package 境界整理
+
+## 非対象
+
+- 解析成功件数の日次推移、月次推移 API
+- 請求金額合計、通貨別合計、Vendor 内訳
+- connection 単位、provider 単位の breakdown
+- frontend ごとのタイムゾーン切り替え
+- workflow 監査 API の置き換え
+
+## 機能要件
+
+- `FR-1`
+  - `GET /api/v1/dashboard/summary` は認証済みユーザーのみ利用できる。
+- `FR-2`
+  - API は自分自身が所有するデータのみを集計対象にする。
+- `FR-3`
+  - レスポンスは少なくとも以下 3 項目を返せる。
+    - `current_month_analysis_success_count`
+    - `total_saved_billing_count`
+    - `fallback_billing_count`
+- `FR-4`
+  - `current_month_analysis_success_count` は「当月に解析ステージで成功し、保存された件数」を意味する。
+- `FR-5`
+  - `total_saved_billing_count` は「これまでに請求として実際に保存された総件数」を意味する。
+- `FR-6`
+  - `fallback_billing_count` は「これまでに請求として実際に保存されたデータのうち、`billing_date` がなく、メール受信日 fallback で判定した総件数」を意味する。
+- `FR-7`
+  - データが存在しない場合でも `200 OK` を返し、各項目は `0` を返せる。
+
+## 非機能要件
+
+- `NFR-1`
+  - HTTP 契約は `docs/api_design.md` に従う。
+- `NFR-2`
+  - JSON フィールド名は `lower_snake_case` とする。
+- `NFR-3`
+  - ダッシュボード初期表示向けに軽量なレスポンスとし、不要な一覧や内訳は返さない。
+- `NFR-4`
+  - 集計は固定本数のクエリで完結し、N+1 を起こさない。
+- `NFR-5`
+  - 月境界の解釈は v1 では UTC に固定する。
+- `NFR-6`
+  - レスポンスや構造化ログにメール本文、メールアドレス、OAuth token、prompt、生の解析結果などの秘匿情報を含めない。
+- `NFR-7`
+  - dashboard KPI は read model として扱い、`Billing` aggregate や `manualmailworkflow` aggregate の意味を変更しない。
+- `NFR-8`
+  - 件数集計は domain に持ち込まず、read repository の SQL 集計で取得する。
+
+## 制約・前提
+
+- `current_month_analysis_success_count` は workflow 履歴 header の合算ではなく、保存済み解析結果を基準に扱う。
+- `total_saved_billing_count` と `fallback_billing_count` は `billings` を基準に扱う。
+- `fallback_billing_count` の判定条件は既存 `fallback_billing_count` と同様に `billings.billing_date IS NULL` を基準にする。
+- `total_saved_billing_count` と `fallback_billing_count` の「実件数と一致」は、値の定義と集計元の意味を示すものであり、別途 reconcile 用の検証処理や同期処理を要求するものではない。
+
+## 成功条件
+
+- `GET /api/v1/dashboard/summary` で、認証済みユーザー自身の 3 KPI を取得できる。
+- フロントのモックを追加変換なしでそのまま描画できる。
+- `current_month_analysis_success_count` が保存済み解析結果ベースの件数として説明できる。
+- `total_saved_billing_count` が保存済み請求件数の意味で解釈できる。
+- `fallback_billing_count` が `billing_date` fallback 件数の意味で解釈できる。
+- データ未作成ユーザーでも response shape が崩れず、`0` / `0` / `0` を返せる。

--- a/internal/app/presentation/dashboard/controller.go
+++ b/internal/app/presentation/dashboard/controller.go
@@ -1,0 +1,89 @@
+package dashboard
+
+import (
+	"business/internal/app/httpresponse"
+	dashboardqueryapp "business/internal/dashboardquery/application"
+	"business/internal/library/logger"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Controller handles dashboard summary HTTP requests.
+type Controller struct {
+	usecase dashboardqueryapp.SummaryUseCaseInterface
+	log     logger.Interface
+}
+
+type summaryResponse struct {
+	CurrentMonthAnalysisSuccessCount int `json:"current_month_analysis_success_count"`
+	TotalSavedBillingCount           int `json:"total_saved_billing_count"`
+	CurrentMonthFallbackBillingCount int `json:"current_month_fallback_billing_count"`
+}
+
+// NewController creates a dashboard summary controller.
+func NewController(usecase dashboardqueryapp.SummaryUseCaseInterface, log logger.Interface) *Controller {
+	if log == nil {
+		log = logger.NewNop()
+	}
+
+	return &Controller{
+		usecase: usecase,
+		log:     log.With(logger.Component("dashboard_summary_controller")),
+	}
+}
+
+// Summary handles GET /api/v1/dashboard/summary.
+func (ctrl *Controller) Summary(c *gin.Context) {
+	reqLog := ctrl.log
+	if withContext, err := ctrl.log.WithContext(c.Request.Context()); err == nil {
+		reqLog = withContext
+	}
+
+	userID, ok := currentUserID(c)
+	if !ok {
+		return
+	}
+
+	if ctrl.usecase == nil {
+		reqLog.Error("dashboard_summary_usecase_not_configured",
+			logger.UserID(userID),
+		)
+		httpresponse.WriteInternalServerError(c)
+		return
+	}
+
+	result, err := ctrl.usecase.Get(c.Request.Context(), dashboardqueryapp.SummaryQuery{
+		UserID: userID,
+	})
+	if err != nil {
+		reqLog.Error("dashboard_summary_failed",
+			logger.UserID(userID),
+			logger.Err(err),
+		)
+		httpresponse.WriteInternalServerError(c)
+		return
+	}
+
+	c.JSON(http.StatusOK, summaryResponse{
+		CurrentMonthAnalysisSuccessCount: result.CurrentMonthAnalysisSuccessCount,
+		TotalSavedBillingCount:           result.TotalSavedBillingCount,
+		CurrentMonthFallbackBillingCount: result.CurrentMonthFallbackBillingCount,
+	})
+}
+
+func currentUserID(c *gin.Context) (uint, bool) {
+	userID, exists := c.Get("userID")
+	if !exists {
+		httpresponse.WriteError(c, http.StatusUnauthorized, "unauthorized", "認証が必要です。")
+		return 0, false
+	}
+
+	uid, ok := userID.(uint)
+	if !ok {
+		httpresponse.WriteInternalServerError(c)
+		return 0, false
+	}
+
+	return uid, true
+}

--- a/internal/app/presentation/dashboard/controller_test.go
+++ b/internal/app/presentation/dashboard/controller_test.go
@@ -1,0 +1,93 @@
+package dashboard
+
+import (
+	dashboardqueryapp "business/internal/dashboardquery/application"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func setUserID(c *gin.Context, uid uint) {
+	c.Set("userID", uid)
+}
+
+func summaryRouter(ctrl *Controller) *gin.Engine {
+	r := gin.New()
+	r.GET("/dashboard/summary", func(c *gin.Context) { setUserID(c, 1) }, ctrl.Summary)
+	return r
+}
+
+func TestSummary_200(t *testing.T) {
+	t.Parallel()
+
+	uc := new(mockSummaryUseCase)
+	uc.
+		On("Get", mock.Anything, dashboardqueryapp.SummaryQuery{UserID: 1}).
+		Return(dashboardqueryapp.SummaryResult{
+			CurrentMonthAnalysisSuccessCount: 1280,
+			TotalSavedBillingCount:           842,
+			CurrentMonthFallbackBillingCount: 73,
+		}, nil).
+		Once()
+
+	ctrl := newTestController(uc)
+	r := summaryRouter(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/summary", nil)
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.JSONEq(t, `{
+		"current_month_analysis_success_count": 1280,
+		"total_saved_billing_count": 842,
+		"current_month_fallback_billing_count": 73
+	}`, resp.Body.String())
+	uc.AssertExpectations(t)
+}
+
+func TestSummary_401_NoUser(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newTestController(new(mockSummaryUseCase))
+
+	r := gin.New()
+	r.GET("/dashboard/summary", ctrl.Summary)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/summary", nil)
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+	assert.Contains(t, resp.Body.String(), "unauthorized")
+}
+
+func TestSummary_500_Internal(t *testing.T) {
+	t.Parallel()
+
+	uc := new(mockSummaryUseCase)
+	uc.
+		On("Get", mock.Anything, dashboardqueryapp.SummaryQuery{UserID: 1}).
+		Return(dashboardqueryapp.SummaryResult{}, errors.New("db fail")).
+		Once()
+
+	ctrl := newTestController(uc)
+	r := summaryRouter(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/summary", nil)
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.Contains(t, resp.Body.String(), "internal_server_error")
+	uc.AssertExpectations(t)
+}

--- a/internal/app/presentation/dashboard/test_helper_test.go
+++ b/internal/app/presentation/dashboard/test_helper_test.go
@@ -1,0 +1,28 @@
+package dashboard
+
+import (
+	dashboardqueryapp "business/internal/dashboardquery/application"
+	"business/internal/library/logger"
+	mocklibrary "business/test/mock/library"
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type mockSummaryUseCase struct {
+	mock.Mock
+}
+
+func (m *mockSummaryUseCase) Get(ctx context.Context, query dashboardqueryapp.SummaryQuery) (dashboardqueryapp.SummaryResult, error) {
+	args := m.Called(ctx, query)
+	result, _ := args.Get(0).(dashboardqueryapp.SummaryResult)
+	return result, args.Error(1)
+}
+
+func newTestLogger() logger.Interface {
+	return mocklibrary.NewNopLogger()
+}
+
+func newTestController(usecase dashboardqueryapp.SummaryUseCaseInterface) *Controller {
+	return NewController(usecase, newTestLogger())
+}

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -4,6 +4,7 @@ import (
 	"business/internal/app/middleware"
 	authpresentation "business/internal/app/presentation/auth"
 	billingpresentation "business/internal/app/presentation/billing"
+	dashboardpresentation "business/internal/app/presentation/dashboard"
 	macpresentation "business/internal/app/presentation/mailaccountconnection"
 	manualpresentation "business/internal/app/presentation/manualmailworkflow"
 	"business/internal/library/logger"
@@ -89,6 +90,19 @@ func Router(g *gin.Engine, container *dig.Container, log logger.Interface, allow
 		group.GET("/summary/monthly-detail/:year_month", authMiddleware.Authenticate(), billingController.MonthDetail)
 	}
 	registerBillingRoutes(g.Group("/api/v1/billings"))
+
+	// Dashboard関連
+	var dashboardController *dashboardpresentation.Controller
+	if err := container.Invoke(func(dc *dashboardpresentation.Controller) {
+		dashboardController = dc
+	}); err != nil {
+		log.Error("failed to resolve dashboard controller", logger.Err(err))
+		return g, err
+	}
+	registerDashboardRoutes := func(group *gin.RouterGroup) {
+		group.GET("/summary", authMiddleware.Authenticate(), dashboardController.Summary)
+	}
+	registerDashboardRoutes(g.Group("/api/v1/dashboard"))
 
 	return g, nil
 }

--- a/internal/app/router/router_test.go
+++ b/internal/app/router/router_test.go
@@ -8,10 +8,12 @@ import (
 	"business/internal/app/middleware"
 	authpresentation "business/internal/app/presentation/auth"
 	billingpresentation "business/internal/app/presentation/billing"
+	dashboardpresentation "business/internal/app/presentation/dashboard"
 	macpresentation "business/internal/app/presentation/mailaccountconnection"
 	manualpresentation "business/internal/app/presentation/manualmailworkflow"
 	"business/internal/auth/domain"
 	billingqueryapp "business/internal/billingquery/application"
+	dashboardqueryapp "business/internal/dashboardquery/application"
 	"business/internal/library/logger"
 	macapp "business/internal/mailaccountconnection/application"
 	macdomain "business/internal/mailaccountconnection/domain"
@@ -129,6 +131,12 @@ func (s *stubBillingMonthDetailUseCase) Get(ctx context.Context, query billingqu
 	return billingqueryapp.MonthDetailResult{VendorItems: []billingqueryapp.MonthDetailVendorItem{}}, nil
 }
 
+type stubDashboardSummaryUseCase struct{}
+
+func (s *stubDashboardSummaryUseCase) Get(ctx context.Context, query dashboardqueryapp.SummaryQuery) (dashboardqueryapp.SummaryResult, error) {
+	return dashboardqueryapp.SummaryResult{}, nil
+}
+
 func TestNewRouterRegistersVersionedAndLegacyRoutes(t *testing.T) {
 	t.Parallel()
 
@@ -166,6 +174,10 @@ func TestNewRouterRegistersVersionedAndLegacyRoutes(t *testing.T) {
 		)
 	})
 	assert.NoError(t, err)
+	err = container.Provide(func() *dashboardpresentation.Controller {
+		return dashboardpresentation.NewController(&stubDashboardSummaryUseCase{}, log)
+	})
+	assert.NoError(t, err)
 
 	domain, _ := osw.GetEnv("DOMAIN")
 	_, err = Router(g, container, log, domain)
@@ -195,6 +207,7 @@ func TestNewRouterRegistersVersionedAndLegacyRoutes(t *testing.T) {
 		"GET /api/v1/billings",
 		"GET /api/v1/billings/summary/monthly-trend",
 		"GET /api/v1/billings/summary/monthly-detail/:year_month",
+		"GET /api/v1/dashboard/summary",
 	}
 	for _, route := range expectedRoutes {
 		assert.Contains(t, routes, route)

--- a/internal/dashboardquery/application/errors.go
+++ b/internal/dashboardquery/application/errors.go
@@ -1,0 +1,8 @@
+package application
+
+import "errors"
+
+var (
+	// ErrInvalidSummaryQuery is returned when the dashboard summary query is invalid.
+	ErrInvalidSummaryQuery = errors.New("dashboard summary query is invalid")
+)

--- a/internal/dashboardquery/application/summary_usecase.go
+++ b/internal/dashboardquery/application/summary_usecase.go
@@ -1,0 +1,117 @@
+package application
+
+import (
+	"business/internal/library/logger"
+	"business/internal/library/timewrapper"
+	"context"
+	"fmt"
+	"time"
+)
+
+// SummaryQuery is the application query for the dashboard summary API.
+type SummaryQuery struct {
+	UserID uint
+}
+
+// Validate checks the minimum contract required for the dashboard summary API.
+func (q SummaryQuery) Validate() error {
+	if q.UserID == 0 {
+		return fmt.Errorf("%w: user_id is required", ErrInvalidSummaryQuery)
+	}
+	return nil
+}
+
+// BillingCounts is the billing-side aggregate used by the dashboard summary API.
+type BillingCounts struct {
+	TotalSavedBillingCount           int
+	CurrentMonthFallbackBillingCount int
+}
+
+// SummaryResult is the usecase result for the dashboard summary API.
+type SummaryResult struct {
+	CurrentMonthAnalysisSuccessCount int
+	TotalSavedBillingCount           int
+	CurrentMonthFallbackBillingCount int
+}
+
+// DashboardSummaryRepository loads the dashboard summary aggregates from storage.
+type DashboardSummaryRepository interface {
+	CountCurrentMonthAnalysisSuccess(ctx context.Context, userID uint, monthStartAt, nextMonthStartAt time.Time) (int, error)
+	GetBillingCounts(ctx context.Context, userID uint, monthStartAt, nextMonthStartAt time.Time) (BillingCounts, error)
+}
+
+// SummaryUseCaseInterface provides the dashboard summary API.
+type SummaryUseCaseInterface interface {
+	Get(ctx context.Context, query SummaryQuery) (SummaryResult, error)
+}
+
+type summaryUseCase struct {
+	repository DashboardSummaryRepository
+	clock      timewrapper.ClockInterface
+	log        logger.Interface
+}
+
+// SummaryUseCase is the concrete dashboard summary usecase type exposed for DI.
+type SummaryUseCase = summaryUseCase
+
+// NewSummaryUseCase creates a dashboard summary usecase.
+func NewSummaryUseCase(
+	repository DashboardSummaryRepository,
+	clock timewrapper.ClockInterface,
+	log logger.Interface,
+) *SummaryUseCase {
+	if clock == nil {
+		clock = timewrapper.NewClock()
+	}
+	if log == nil {
+		log = logger.NewNop()
+	}
+
+	return &summaryUseCase{
+		repository: repository,
+		clock:      clock,
+		log:        log.With(logger.Component("dashboard_summary_usecase")),
+	}
+}
+
+// Get returns the authenticated user's dashboard summary.
+func (uc *summaryUseCase) Get(ctx context.Context, query SummaryQuery) (SummaryResult, error) {
+	if ctx == nil {
+		return SummaryResult{}, logger.ErrNilContext
+	}
+	if uc.repository == nil {
+		return SummaryResult{}, fmt.Errorf("dashboard_summary_repository is not configured")
+	}
+	if err := query.Validate(); err != nil {
+		return SummaryResult{}, err
+	}
+
+	currentMonthStartAt, nextMonthStartAt := currentMonthRangeUTC(uc.clock.Now())
+
+	currentMonthAnalysisSuccessCount, err := uc.repository.CountCurrentMonthAnalysisSuccess(
+		ctx,
+		query.UserID,
+		currentMonthStartAt,
+		nextMonthStartAt,
+	)
+	if err != nil {
+		return SummaryResult{}, err
+	}
+
+	billingCounts, err := uc.repository.GetBillingCounts(ctx, query.UserID, currentMonthStartAt, nextMonthStartAt)
+	if err != nil {
+		return SummaryResult{}, err
+	}
+
+	return SummaryResult{
+		CurrentMonthAnalysisSuccessCount: currentMonthAnalysisSuccessCount,
+		TotalSavedBillingCount:           billingCounts.TotalSavedBillingCount,
+		CurrentMonthFallbackBillingCount: billingCounts.CurrentMonthFallbackBillingCount,
+	}, nil
+}
+
+func currentMonthRangeUTC(now time.Time) (time.Time, time.Time) {
+	utcNow := now.UTC()
+	currentMonthStartAt := time.Date(utcNow.Year(), utcNow.Month(), 1, 0, 0, 0, 0, time.UTC)
+	return currentMonthStartAt, currentMonthStartAt.AddDate(0, 1, 0)
+}

--- a/internal/dashboardquery/application/summary_usecase_test.go
+++ b/internal/dashboardquery/application/summary_usecase_test.go
@@ -1,0 +1,166 @@
+package application
+
+import (
+	"business/internal/library/logger"
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type stubDashboardSummaryRepository struct {
+	countCurrentMonthAnalysisSuccess func(ctx context.Context, userID uint, monthStartAt, nextMonthStartAt time.Time) (int, error)
+	getBillingCounts                 func(ctx context.Context, userID uint, monthStartAt, nextMonthStartAt time.Time) (BillingCounts, error)
+}
+
+func (s *stubDashboardSummaryRepository) CountCurrentMonthAnalysisSuccess(
+	ctx context.Context,
+	userID uint,
+	monthStartAt,
+	nextMonthStartAt time.Time,
+) (int, error) {
+	return s.countCurrentMonthAnalysisSuccess(ctx, userID, monthStartAt, nextMonthStartAt)
+}
+
+func (s *stubDashboardSummaryRepository) GetBillingCounts(
+	ctx context.Context,
+	userID uint,
+	monthStartAt,
+	nextMonthStartAt time.Time,
+) (BillingCounts, error) {
+	return s.getBillingCounts(ctx, userID, monthStartAt, nextMonthStartAt)
+}
+
+type dashboardSummaryFixedClock struct {
+	now time.Time
+}
+
+func (c *dashboardSummaryFixedClock) Now() time.Time {
+	return c.now
+}
+
+func (c *dashboardSummaryFixedClock) After(d time.Duration) <-chan time.Time {
+	ch := make(chan time.Time, 1)
+	ch <- c.now.Add(d)
+	return ch
+}
+
+func TestSummaryUseCase_Get_UsesUTCCurrentMonthAndBuildsResult(t *testing.T) {
+	t.Parallel()
+
+	jst := time.FixedZone("JST", 9*60*60)
+	now := time.Date(2026, 4, 1, 8, 30, 0, 0, jst)
+
+	var capturedUserID uint
+	var capturedMonthStartAt time.Time
+	var capturedNextMonthStartAt time.Time
+
+	uc := NewSummaryUseCase(&stubDashboardSummaryRepository{
+		countCurrentMonthAnalysisSuccess: func(
+			ctx context.Context,
+			userID uint,
+			monthStartAt,
+			nextMonthStartAt time.Time,
+		) (int, error) {
+			capturedUserID = userID
+			capturedMonthStartAt = monthStartAt
+			capturedNextMonthStartAt = nextMonthStartAt
+			return 12, nil
+		},
+		getBillingCounts: func(ctx context.Context, userID uint, monthStartAt, nextMonthStartAt time.Time) (BillingCounts, error) {
+			if userID != 7 {
+				t.Fatalf("unexpected userID for billing counts: %d", userID)
+			}
+			expectedMonthStartAt := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+			expectedNextMonthStartAt := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+			if !monthStartAt.Equal(expectedMonthStartAt) {
+				t.Fatalf("expected billing monthStartAt %s, got %s", expectedMonthStartAt, monthStartAt)
+			}
+			if !nextMonthStartAt.Equal(expectedNextMonthStartAt) {
+				t.Fatalf("expected billing nextMonthStartAt %s, got %s", expectedNextMonthStartAt, nextMonthStartAt)
+			}
+			return BillingCounts{
+				TotalSavedBillingCount:           34,
+				CurrentMonthFallbackBillingCount: 5,
+			}, nil
+		},
+	}, &dashboardSummaryFixedClock{now: now}, logger.NewNop())
+
+	result, err := uc.Get(context.Background(), SummaryQuery{UserID: 7})
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+
+	if capturedUserID != 7 {
+		t.Fatalf("expected userID 7, got %d", capturedUserID)
+	}
+	expectedMonthStartAt := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	expectedNextMonthStartAt := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	if !capturedMonthStartAt.Equal(expectedMonthStartAt) {
+		t.Fatalf("expected monthStartAt %s, got %s", expectedMonthStartAt, capturedMonthStartAt)
+	}
+	if !capturedNextMonthStartAt.Equal(expectedNextMonthStartAt) {
+		t.Fatalf("expected nextMonthStartAt %s, got %s", expectedNextMonthStartAt, capturedNextMonthStartAt)
+	}
+
+	if result.CurrentMonthAnalysisSuccessCount != 12 {
+		t.Fatalf("unexpected current month analysis success count: %+v", result)
+	}
+	if result.TotalSavedBillingCount != 34 {
+		t.Fatalf("unexpected total saved billing count: %+v", result)
+	}
+	if result.CurrentMonthFallbackBillingCount != 5 {
+		t.Fatalf("unexpected current month fallback billing count: %+v", result)
+	}
+}
+
+func TestSummaryUseCase_Get_RejectsInvalidQuery(t *testing.T) {
+	t.Parallel()
+
+	uc := NewSummaryUseCase(&stubDashboardSummaryRepository{
+		countCurrentMonthAnalysisSuccess: func(
+			ctx context.Context,
+			userID uint,
+			monthStartAt,
+			nextMonthStartAt time.Time,
+		) (int, error) {
+			t.Fatal("repository should not be called for invalid query")
+			return 0, nil
+		},
+		getBillingCounts: func(ctx context.Context, userID uint, monthStartAt, nextMonthStartAt time.Time) (BillingCounts, error) {
+			t.Fatal("repository should not be called for invalid query")
+			return BillingCounts{}, nil
+		},
+	}, &dashboardSummaryFixedClock{now: time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)}, logger.NewNop())
+
+	_, err := uc.Get(context.Background(), SummaryQuery{})
+	if !errors.Is(err, ErrInvalidSummaryQuery) {
+		t.Fatalf("expected ErrInvalidSummaryQuery, got %v", err)
+	}
+}
+
+func TestSummaryUseCase_Get_ReturnsZeroCounts(t *testing.T) {
+	t.Parallel()
+
+	uc := NewSummaryUseCase(&stubDashboardSummaryRepository{
+		countCurrentMonthAnalysisSuccess: func(
+			ctx context.Context,
+			userID uint,
+			monthStartAt,
+			nextMonthStartAt time.Time,
+		) (int, error) {
+			return 0, nil
+		},
+		getBillingCounts: func(ctx context.Context, userID uint, monthStartAt, nextMonthStartAt time.Time) (BillingCounts, error) {
+			return BillingCounts{}, nil
+		},
+	}, &dashboardSummaryFixedClock{now: time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)}, logger.NewNop())
+
+	result, err := uc.Get(context.Background(), SummaryQuery{UserID: 1})
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if result.CurrentMonthAnalysisSuccessCount != 0 || result.TotalSavedBillingCount != 0 || result.CurrentMonthFallbackBillingCount != 0 {
+		t.Fatalf("expected zero counts, got %+v", result)
+	}
+}

--- a/internal/dashboardquery/infrastructure/repository.go
+++ b/internal/dashboardquery/infrastructure/repository.go
@@ -1,0 +1,158 @@
+package infrastructure
+
+import (
+	dashboardqueryapp "business/internal/dashboardquery/application"
+	"business/internal/library/logger"
+	"context"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type parsedEmailSummaryRecord struct {
+	ID          uint      `gorm:"column:id;primaryKey;autoIncrement"`
+	UserID      uint      `gorm:"column:user_id;not null;index:idx_parsed_emails_user_email,priority:1"`
+	EmailID     uint      `gorm:"column:email_id;not null;index:idx_parsed_emails_user_email,priority:2"`
+	ExtractedAt time.Time `gorm:"column:extracted_at;not null"`
+	CreatedAt   time.Time `gorm:"column:created_at;not null"`
+	UpdatedAt   time.Time `gorm:"column:updated_at;not null"`
+}
+
+func (parsedEmailSummaryRecord) TableName() string {
+	return "parsed_emails"
+}
+
+type billingSummaryRecord struct {
+	ID                 uint       `gorm:"column:id;primaryKey;autoIncrement"`
+	UserID             uint       `gorm:"column:user_id;not null;index:idx_billings_user_summary_date_id,priority:1"`
+	BillingDate        *time.Time `gorm:"column:billing_date"`
+	BillingSummaryDate time.Time  `gorm:"column:billing_summary_date;not null;index:idx_billings_user_summary_date_id,priority:2"`
+	CreatedAt          time.Time  `gorm:"column:created_at;not null"`
+	UpdatedAt          time.Time  `gorm:"column:updated_at;not null"`
+}
+
+func (billingSummaryRecord) TableName() string {
+	return "billings"
+}
+
+type billingCountsRow struct {
+	TotalSavedBillingCount           int64 `gorm:"column:total_saved_billing_count"`
+	CurrentMonthFallbackBillingCount int64 `gorm:"column:current_month_fallback_billing_count"`
+}
+
+// DashboardSummaryRepository loads dashboard summary read models from MySQL.
+type DashboardSummaryRepository struct {
+	db  *gorm.DB
+	log logger.Interface
+}
+
+// NewDashboardSummaryRepository creates a dashboard summary repository backed by MySQL.
+func NewDashboardSummaryRepository(
+	db *gorm.DB,
+	log logger.Interface,
+) *DashboardSummaryRepository {
+	if log == nil {
+		log = logger.NewNop()
+	}
+
+	return &DashboardSummaryRepository{
+		db:  db,
+		log: log.With(logger.Component("dashboard_summary_repository")),
+	}
+}
+
+// CountCurrentMonthAnalysisSuccess counts the parsed emails saved in the current UTC month.
+func (r *DashboardSummaryRepository) CountCurrentMonthAnalysisSuccess(
+	ctx context.Context,
+	userID uint,
+	monthStartAt,
+	nextMonthStartAt time.Time,
+) (int, error) {
+	if ctx == nil {
+		return 0, logger.ErrNilContext
+	}
+	if r.db == nil {
+		return 0, fmt.Errorf("gorm db is not configured")
+	}
+	if userID == 0 {
+		return 0, fmt.Errorf("user_id is required")
+	}
+	if monthStartAt.IsZero() || nextMonthStartAt.IsZero() || !monthStartAt.Before(nextMonthStartAt) {
+		return 0, fmt.Errorf("invalid current month range")
+	}
+
+	reqLog := r.log
+	if withContext, err := r.log.WithContext(ctx); err == nil {
+		reqLog = withContext
+	}
+
+	var count int64
+	if err := r.db.WithContext(ctx).
+		Table("parsed_emails").
+		Where("user_id = ?", userID).
+		Where("extracted_at >= ?", monthStartAt.UTC()).
+		Where("extracted_at < ?", nextMonthStartAt.UTC()).
+		Count(&count).Error; err != nil {
+		reqLog.Error("db_query_failed",
+			logger.String("db_system", "mysql"),
+			logger.String("table", "parsed_emails"),
+			logger.String("operation", "count_current_month_analysis_success"),
+			logger.Err(err),
+		)
+		return 0, fmt.Errorf("failed to count current month analysis success: %w", err)
+	}
+
+	return int(count), nil
+}
+
+// GetBillingCounts loads the total saved billing count and current-month fallback billing count.
+func (r *DashboardSummaryRepository) GetBillingCounts(
+	ctx context.Context,
+	userID uint,
+	monthStartAt,
+	nextMonthStartAt time.Time,
+) (dashboardqueryapp.BillingCounts, error) {
+	if ctx == nil {
+		return dashboardqueryapp.BillingCounts{}, logger.ErrNilContext
+	}
+	if r.db == nil {
+		return dashboardqueryapp.BillingCounts{}, fmt.Errorf("gorm db is not configured")
+	}
+	if userID == 0 {
+		return dashboardqueryapp.BillingCounts{}, fmt.Errorf("user_id is required")
+	}
+	if monthStartAt.IsZero() || nextMonthStartAt.IsZero() || !monthStartAt.Before(nextMonthStartAt) {
+		return dashboardqueryapp.BillingCounts{}, fmt.Errorf("invalid current month range")
+	}
+
+	reqLog := r.log
+	if withContext, err := r.log.WithContext(ctx); err == nil {
+		reqLog = withContext
+	}
+
+	var row billingCountsRow
+	if err := r.db.WithContext(ctx).
+		Table("billings").
+		Select(
+			"COUNT(*) AS total_saved_billing_count, "+
+				"COALESCE(SUM(CASE WHEN billing_date IS NULL AND billing_summary_date >= ? AND billing_summary_date < ? THEN 1 ELSE 0 END), 0) AS current_month_fallback_billing_count",
+			monthStartAt.UTC(),
+			nextMonthStartAt.UTC(),
+		).
+		Where("user_id = ?", userID).
+		Scan(&row).Error; err != nil {
+		reqLog.Error("db_query_failed",
+			logger.String("db_system", "mysql"),
+			logger.String("table", "billings"),
+			logger.String("operation", "count_dashboard_summary_billings"),
+			logger.Err(err),
+		)
+		return dashboardqueryapp.BillingCounts{}, fmt.Errorf("failed to count dashboard summary billings: %w", err)
+	}
+
+	return dashboardqueryapp.BillingCounts{
+		TotalSavedBillingCount:           int(row.TotalSavedBillingCount),
+		CurrentMonthFallbackBillingCount: int(row.CurrentMonthFallbackBillingCount),
+	}, nil
+}

--- a/internal/dashboardquery/infrastructure/repository_test.go
+++ b/internal/dashboardquery/infrastructure/repository_test.go
@@ -1,0 +1,143 @@
+package infrastructure
+
+import (
+	dashboardqueryapp "business/internal/dashboardquery/application"
+	"business/internal/library/logger"
+	"business/internal/library/mysql"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type dashboardSummaryRepoTestEnv struct {
+	repo  *DashboardSummaryRepository
+	db    *gorm.DB
+	clean func() error
+}
+
+func newDashboardSummaryRepoTestEnv(t *testing.T) *dashboardSummaryRepoTestEnv {
+	t.Helper()
+
+	mysqlConn, cleanup, err := mysql.CreateNewTestDB()
+	if err != nil {
+		skipIfDashboardSummaryRepoDBUnavailable(t, err)
+	}
+	require.NoError(t, err)
+	require.NoError(t, mysqlConn.DB.AutoMigrate(
+		&parsedEmailSummaryRecord{},
+		&billingSummaryRecord{},
+	))
+
+	return &dashboardSummaryRepoTestEnv{
+		repo:  NewDashboardSummaryRepository(mysqlConn.DB, logger.NewNop()),
+		db:    mysqlConn.DB,
+		clean: cleanup,
+	}
+}
+
+func skipIfDashboardSummaryRepoDBUnavailable(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	if strings.Contains(err.Error(), "dial tcp") || strings.Contains(err.Error(), "lookup mysql") {
+		t.Skipf("Skipping repository integration test: %v", err)
+	}
+}
+
+func seedDashboardSummaryFixtures(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	march1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	march15 := time.Date(2026, 3, 15, 9, 30, 0, 0, time.UTC)
+	march31 := time.Date(2026, 3, 31, 23, 59, 59, 0, time.UTC)
+	april1 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	april3 := time.Date(2026, 4, 3, 10, 0, 0, 0, time.UTC)
+	feb28 := time.Date(2026, 2, 28, 23, 59, 59, 0, time.UTC)
+	billingDate := time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC)
+
+	parsedEmails := []parsedEmailSummaryRecord{
+		{ID: 1, UserID: 1, EmailID: 101, ExtractedAt: march1, CreatedAt: now, UpdatedAt: now},
+		{ID: 2, UserID: 1, EmailID: 102, ExtractedAt: march15, CreatedAt: now, UpdatedAt: now},
+		{ID: 3, UserID: 1, EmailID: 103, ExtractedAt: march31, CreatedAt: now, UpdatedAt: now},
+		{ID: 4, UserID: 1, EmailID: 104, ExtractedAt: feb28, CreatedAt: now, UpdatedAt: now},
+		{ID: 5, UserID: 1, EmailID: 105, ExtractedAt: april1, CreatedAt: now, UpdatedAt: now},
+		{ID: 6, UserID: 2, EmailID: 201, ExtractedAt: march15, CreatedAt: now, UpdatedAt: now},
+	}
+	require.NoError(t, db.Create(&parsedEmails).Error)
+
+	billings := []billingSummaryRecord{
+		{ID: 201, UserID: 1, BillingDate: &billingDate, BillingSummaryDate: billingDate, CreatedAt: now, UpdatedAt: now},
+		{ID: 202, UserID: 1, BillingDate: nil, BillingSummaryDate: march15, CreatedAt: now, UpdatedAt: now},
+		{ID: 203, UserID: 1, BillingDate: nil, BillingSummaryDate: april3, CreatedAt: now, UpdatedAt: now},
+		{ID: 204, UserID: 2, BillingDate: nil, BillingSummaryDate: march31, CreatedAt: now, UpdatedAt: now},
+	}
+	require.NoError(t, db.Create(&billings).Error)
+}
+
+func TestDashboardSummaryRepository_CountCurrentMonthAnalysisSuccess_AppliesUserScopeAndMonthRange(t *testing.T) {
+	t.Parallel()
+
+	env := newDashboardSummaryRepoTestEnv(t)
+	defer env.clean()
+	seedDashboardSummaryFixtures(t, env.db)
+
+	count, err := env.repo.CountCurrentMonthAnalysisSuccess(
+		context.Background(),
+		1,
+		time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 3, count)
+}
+
+func TestDashboardSummaryRepository_GetBillingCounts_AppliesUserScope(t *testing.T) {
+	t.Parallel()
+
+	env := newDashboardSummaryRepoTestEnv(t)
+	defer env.clean()
+	seedDashboardSummaryFixtures(t, env.db)
+
+	result, err := env.repo.GetBillingCounts(
+		context.Background(),
+		1,
+		time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+	)
+	require.NoError(t, err)
+	require.Equal(t, dashboardqueryapp.BillingCounts{
+		TotalSavedBillingCount:           3,
+		CurrentMonthFallbackBillingCount: 1,
+	}, result)
+}
+
+func TestDashboardSummaryRepository_ReturnsZeroCountsWithoutData(t *testing.T) {
+	t.Parallel()
+
+	env := newDashboardSummaryRepoTestEnv(t)
+	defer env.clean()
+
+	count, err := env.repo.CountCurrentMonthAnalysisSuccess(
+		context.Background(),
+		1,
+		time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+
+	result, err := env.repo.GetBillingCounts(
+		context.Background(),
+		1,
+		time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+	)
+	require.NoError(t, err)
+	require.Equal(t, dashboardqueryapp.BillingCounts{}, result)
+}

--- a/internal/di/dashboard.go
+++ b/internal/di/dashboard.go
@@ -1,0 +1,37 @@
+package di
+
+import (
+	dashboardpresentation "business/internal/app/presentation/dashboard"
+	dashboardqueryapp "business/internal/dashboardquery/application"
+	dashboardqueryinfra "business/internal/dashboardquery/infrastructure"
+	"business/internal/library/logger"
+	"business/internal/library/timewrapper"
+
+	"go.uber.org/dig"
+	"gorm.io/gorm"
+)
+
+// ProvideDashboardDependencies registers dashboard summary dependencies.
+func ProvideDashboardDependencies(container *dig.Container) {
+	_ = container.Provide(func(
+		db *gorm.DB,
+		log *logger.Logger,
+	) *dashboardqueryinfra.DashboardSummaryRepository {
+		return dashboardqueryinfra.NewDashboardSummaryRepository(db, log)
+	})
+
+	_ = container.Provide(func(
+		repository *dashboardqueryinfra.DashboardSummaryRepository,
+		clock *timewrapper.Clock,
+		log *logger.Logger,
+	) *dashboardqueryapp.SummaryUseCase {
+		return dashboardqueryapp.NewSummaryUseCase(repository, clock, log)
+	})
+
+	_ = container.Provide(func(
+		usecase *dashboardqueryapp.SummaryUseCase,
+		log *logger.Logger,
+	) *dashboardpresentation.Controller {
+		return dashboardpresentation.NewController(usecase, log)
+	})
+}

--- a/internal/di/di_test.go
+++ b/internal/di/di_test.go
@@ -5,6 +5,7 @@ import (
 
 	"business/internal/app/middleware"
 	authpresentation "business/internal/app/presentation/auth"
+	dashboardpresentation "business/internal/app/presentation/dashboard"
 	manualpresentation "business/internal/app/presentation/manualmailworkflow"
 	"business/internal/auth/application"
 	"business/internal/library/crypto"
@@ -95,11 +96,13 @@ func TestBuildContainer_ResolvesAuthPresentation(t *testing.T) {
 
 	err := container.Invoke(func(
 		controller *authpresentation.Controller,
+		dashboardController *dashboardpresentation.Controller,
 		manualController *manualpresentation.Controller,
 		authMiddleware *middleware.AuthMiddleware,
 		usecase *application.AuthUseCase,
 	) {
 		assert.NotNil(t, controller)
+		assert.NotNil(t, dashboardController)
 		assert.NotNil(t, manualController)
 		assert.NotNil(t, authMiddleware)
 		assert.NotNil(t, usecase)

--- a/internal/di/dig.go
+++ b/internal/di/dig.go
@@ -97,6 +97,7 @@ func BuildContainer(
 	ProvideVendorResolutionDependencies(container)
 	ProvideBillingEligibilityDependencies(container)
 	ProvideBillingDependencies(container)
+	ProvideDashboardDependencies(container)
 	ProvideManualMailWorkflowDependencies(container)
 	ProvidePresentationDependencies(container)
 

--- a/test/scenario/dashboard_summary/dashboard_summary_scenario_helpers_test.go
+++ b/test/scenario/dashboard_summary/dashboard_summary_scenario_helpers_test.go
@@ -1,0 +1,245 @@
+package test
+
+import (
+	"business/internal/app/middleware"
+	authpresentation "business/internal/app/presentation/auth"
+	billingpresentation "business/internal/app/presentation/billing"
+	dashboardpresentation "business/internal/app/presentation/dashboard"
+	macpresentation "business/internal/app/presentation/mailaccountconnection"
+	manualpresentation "business/internal/app/presentation/manualmailworkflow"
+	v1 "business/internal/app/router"
+	authdomain "business/internal/auth/domain"
+	authinfra "business/internal/auth/infrastructure"
+	dashboardqueryapp "business/internal/dashboardquery/application"
+	dashboardqueryinfra "business/internal/dashboardquery/infrastructure"
+	"business/internal/library/logger"
+	"business/internal/library/mysql"
+	mocklibrary "business/test/mock/library"
+	model "business/tools/migrations/models"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/dig"
+	"gorm.io/gorm"
+)
+
+const (
+	dashboardSummaryScenarioJWTSecret     = "scenario-jwt-secret"
+	dashboardSummaryScenarioAllowedOrigin = "http://localhost:3000"
+)
+
+type dashboardSummaryScenarioEnv struct {
+	t           *testing.T
+	db          *gorm.DB
+	router      *gin.Engine
+	clock       *dashboardSummaryScenarioClock
+	userID      uint
+	otherUserID uint
+}
+
+type dashboardSummaryScenarioClock struct {
+	now time.Time
+}
+
+type dashboardSummaryResponse struct {
+	CurrentMonthAnalysisSuccessCount int `json:"current_month_analysis_success_count"`
+	TotalSavedBillingCount           int `json:"total_saved_billing_count"`
+	CurrentMonthFallbackBillingCount int `json:"current_month_fallback_billing_count"`
+}
+
+type dashboardSummaryErrorResponse struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func (c *dashboardSummaryScenarioClock) Now() time.Time {
+	return c.now
+}
+
+func (c *dashboardSummaryScenarioClock) After(d time.Duration) <-chan time.Time {
+	ch := make(chan time.Time, 1)
+	ch <- c.now.Add(d)
+	return ch
+}
+
+func newDashboardSummaryScenarioEnv(t *testing.T) *dashboardSummaryScenarioEnv {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	mysqlConn, cleanup, err := mysql.CreateNewTestDB()
+	if err != nil {
+		skipDashboardSummaryScenarioDBUnavailable(t, err)
+	}
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if cleanup != nil {
+			require.NoError(t, cleanup())
+		}
+	})
+
+	require.NoError(t, mysqlConn.DB.AutoMigrate(
+		&model.User{},
+		&model.Email{},
+		&model.ParsedEmail{},
+		&model.Billing{},
+	))
+
+	log := logger.NewNop()
+	osw := mocklibrary.NewOsWrapperMock(map[string]string{
+		"APP":            "test",
+		"DOMAIN":         "localhost",
+		"JWT_SECRET_KEY": dashboardSummaryScenarioJWTSecret,
+	})
+
+	authRepo := authinfra.NewRepository(mysqlConn.DB, log)
+	authMiddleware := middleware.NewAuthMiddleware(osw, authRepo, log)
+	authController := authpresentation.NewController(nil, log, osw)
+
+	clock := &dashboardSummaryScenarioClock{
+		now: time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	}
+	dashboardRepository := dashboardqueryinfra.NewDashboardSummaryRepository(mysqlConn.DB, log)
+	dashboardUseCase := dashboardqueryapp.NewSummaryUseCase(dashboardRepository, clock, log)
+	dashboardController := dashboardpresentation.NewController(dashboardUseCase, log)
+
+	router := gin.New()
+	container := dig.New()
+	require.NoError(t, container.Provide(func() *authpresentation.Controller { return authController }))
+	require.NoError(t, container.Provide(func() *middleware.AuthMiddleware { return authMiddleware }))
+	require.NoError(t, container.Provide(func() *macpresentation.Controller {
+		return macpresentation.NewController(nil, log)
+	}))
+	require.NoError(t, container.Provide(func() *manualpresentation.Controller {
+		return manualpresentation.NewController(nil, nil, log)
+	}))
+	require.NoError(t, container.Provide(func() *billingpresentation.Controller {
+		return billingpresentation.NewController(nil, nil, nil, log)
+	}))
+	require.NoError(t, container.Provide(func() *dashboardpresentation.Controller { return dashboardController }))
+
+	_, err = v1.Router(router, container, log, dashboardSummaryScenarioAllowedOrigin)
+	require.NoError(t, err)
+
+	env := &dashboardSummaryScenarioEnv{
+		t:      t,
+		db:     mysqlConn.DB,
+		router: router,
+		clock:  clock,
+	}
+	env.userID = env.mustCreateVerifiedUser("dashboard-scenario-user-1", "dashboard-scenario-user-1@example.com")
+	env.otherUserID = env.mustCreateVerifiedUser("dashboard-scenario-user-2", "dashboard-scenario-user-2@example.com")
+	return env
+}
+
+func skipDashboardSummaryScenarioDBUnavailable(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+
+	msg := err.Error()
+	skipPatterns := []string{
+		"dial tcp",
+		"connect: connection refused",
+		"lookup mysql",
+		"access denied",
+		"environment variable MYSQL_",
+		"environment variable DB_HOST",
+	}
+	for _, pattern := range skipPatterns {
+		if strings.Contains(msg, pattern) {
+			t.Skipf("Skipping DashboardSummary scenario test: %v", err)
+		}
+	}
+}
+
+func (e *dashboardSummaryScenarioEnv) mustCreateVerifiedUser(name, email string) uint {
+	e.t.Helper()
+
+	now := e.clock.Now().UTC()
+	user := model.User{
+		Name:            name,
+		Email:           email,
+		Password:        "$2a$10$abcdefghijklmnopqrstuv",
+		EmailVerified:   true,
+		EmailVerifiedAt: &now,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	require.NoError(e.t, e.db.Create(&user).Error)
+	return user.ID
+}
+
+func (e *dashboardSummaryScenarioEnv) mustInsertParsedEmails(rows []model.ParsedEmail) {
+	e.t.Helper()
+	require.NoError(e.t, e.db.Create(&rows).Error)
+}
+
+func (e *dashboardSummaryScenarioEnv) mustInsertBillings(rows []model.Billing) {
+	e.t.Helper()
+	require.NoError(e.t, e.db.Create(&rows).Error)
+}
+
+func (e *dashboardSummaryScenarioEnv) getSummary(userID uint) *httptest.ResponseRecorder {
+	e.t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dashboard/summary", nil)
+	req.Header.Set("Authorization", "Bearer "+e.mustIssueJWT(userID))
+
+	resp := httptest.NewRecorder()
+	e.router.ServeHTTP(resp, req)
+	return resp
+}
+
+func (e *dashboardSummaryScenarioEnv) getSummaryWithoutAuth() *httptest.ResponseRecorder {
+	e.t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dashboard/summary", nil)
+	resp := httptest.NewRecorder()
+	e.router.ServeHTTP(resp, req)
+	return resp
+}
+
+func (e *dashboardSummaryScenarioEnv) mustIssueJWT(userID uint) string {
+	e.t.Helper()
+
+	claims := authdomain.AuthClaims{
+		UserID: userID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(e.clock.Now().Add(1 * time.Hour)),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte(dashboardSummaryScenarioJWTSecret))
+	require.NoError(e.t, err)
+	return signed
+}
+
+func (e *dashboardSummaryScenarioEnv) mustDecodeSummaryResponse(resp *httptest.ResponseRecorder) dashboardSummaryResponse {
+	e.t.Helper()
+	var out dashboardSummaryResponse
+	e.mustDecodeResponse(resp, &out)
+	return out
+}
+
+func (e *dashboardSummaryScenarioEnv) mustDecodeErrorResponse(resp *httptest.ResponseRecorder) dashboardSummaryErrorResponse {
+	e.t.Helper()
+	var out dashboardSummaryErrorResponse
+	e.mustDecodeResponse(resp, &out)
+	return out
+}
+
+func (e *dashboardSummaryScenarioEnv) mustDecodeResponse(resp *httptest.ResponseRecorder, out any) {
+	e.t.Helper()
+	require.NoError(e.t, json.Unmarshal(resp.Body.Bytes(), out))
+}

--- a/test/scenario/dashboard_summary/dashboard_summary_scenario_test.go
+++ b/test/scenario/dashboard_summary/dashboard_summary_scenario_test.go
@@ -1,0 +1,57 @@
+package test
+
+import (
+	model "business/tools/migrations/models"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDashboardSummary_Scenario_ReturnsAuthenticatedUsersCurrentMonthKPIs(t *testing.T) {
+	env := newDashboardSummaryScenarioEnv(t)
+
+	now := env.clock.Now().UTC()
+	aprilStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	aprilEnd := time.Date(2026, 4, 30, 23, 59, 59, 0, time.UTC)
+	aprilMiddle := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+	marchEnd := time.Date(2026, 3, 31, 23, 59, 59, 0, time.UTC)
+	mayStart := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	aprilSecond := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
+
+	env.mustInsertParsedEmails([]model.ParsedEmail{
+		{UserID: env.userID, EmailID: 101, AnalysisRunID: "run-april-start", Position: 0, ExtractedAt: aprilStart, PromptVersion: "v1", CreatedAt: now, UpdatedAt: now},
+		{UserID: env.userID, EmailID: 102, AnalysisRunID: "run-april-end", Position: 0, ExtractedAt: aprilEnd, PromptVersion: "v1", CreatedAt: now, UpdatedAt: now},
+		{UserID: env.userID, EmailID: 103, AnalysisRunID: "run-march-end", Position: 0, ExtractedAt: marchEnd, PromptVersion: "v1", CreatedAt: now, UpdatedAt: now},
+		{UserID: env.userID, EmailID: 104, AnalysisRunID: "run-may-start", Position: 0, ExtractedAt: mayStart, PromptVersion: "v1", CreatedAt: now, UpdatedAt: now},
+		{UserID: env.otherUserID, EmailID: 201, AnalysisRunID: "run-other-user", Position: 0, ExtractedAt: aprilMiddle, PromptVersion: "v1", CreatedAt: now, UpdatedAt: now},
+	})
+
+	env.mustInsertBillings([]model.Billing{
+		{UserID: env.userID, VendorID: 1, EmailID: 301, BillingNumber: "billing-1", BillingDate: nil, BillingSummaryDate: aprilStart, PaymentCycle: "monthly", CreatedAt: now, UpdatedAt: now},
+		{UserID: env.userID, VendorID: 2, EmailID: 302, BillingNumber: "billing-2", BillingDate: &aprilSecond, BillingSummaryDate: aprilSecond, PaymentCycle: "monthly", CreatedAt: now, UpdatedAt: now},
+		{UserID: env.userID, VendorID: 3, EmailID: 303, BillingNumber: "billing-3", BillingDate: nil, BillingSummaryDate: marchEnd, PaymentCycle: "monthly", CreatedAt: now, UpdatedAt: now},
+		{UserID: env.userID, VendorID: 4, EmailID: 304, BillingNumber: "billing-4", BillingDate: nil, BillingSummaryDate: mayStart, PaymentCycle: "monthly", CreatedAt: now, UpdatedAt: now},
+		{UserID: env.otherUserID, VendorID: 5, EmailID: 401, BillingNumber: "billing-5", BillingDate: nil, BillingSummaryDate: aprilMiddle, PaymentCycle: "monthly", CreatedAt: now, UpdatedAt: now},
+	})
+
+	resp := env.getSummary(env.userID)
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.Equal(t, dashboardSummaryResponse{
+		CurrentMonthAnalysisSuccessCount: 2,
+		TotalSavedBillingCount:           4,
+		CurrentMonthFallbackBillingCount: 1,
+	}, env.mustDecodeSummaryResponse(resp))
+}
+
+func TestDashboardSummary_Scenario_RejectsMissingAuthorizationToken(t *testing.T) {
+	env := newDashboardSummaryScenarioEnv(t)
+
+	resp := env.getSummaryWithoutAuth()
+	require.Equal(t, http.StatusUnauthorized, resp.Code)
+
+	body := env.mustDecodeErrorResponse(resp)
+	require.Equal(t, "missing_token", body.Error.Code)
+	require.Equal(t, "認証トークンがありません。", body.Error.Message)
+}

--- a/test/scenario/mail_account_connection/mail_account_connection_scenario_helpers_test.go
+++ b/test/scenario/mail_account_connection/mail_account_connection_scenario_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"business/internal/app/middleware"
 	authpresentation "business/internal/app/presentation/auth"
 	billingpresentation "business/internal/app/presentation/billing"
+	dashboardpresentation "business/internal/app/presentation/dashboard"
 	macpresentation "business/internal/app/presentation/mailaccountconnection"
 	manualpresentation "business/internal/app/presentation/manualmailworkflow"
 	v1 "business/internal/app/router"
@@ -11,6 +12,7 @@ import (
 	authdomain "business/internal/auth/domain"
 	authinfra "business/internal/auth/infrastructure"
 	billingqueryapp "business/internal/billingquery/application"
+	dashboardqueryapp "business/internal/dashboardquery/application"
 	"business/internal/library/crypto"
 	"business/internal/library/gmailService"
 	"business/internal/library/logger"
@@ -117,6 +119,8 @@ type scenarioStubBillingMonthlyTrendUseCase struct{}
 
 type scenarioStubBillingMonthDetailUseCase struct{}
 
+type scenarioStubDashboardSummaryUseCase struct{}
+
 func newMailAccountConnectionScenarioEnv(t *testing.T) *mailAccountConnectionScenarioEnv {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
@@ -173,6 +177,7 @@ func newMailAccountConnectionScenarioEnv(t *testing.T) *mailAccountConnectionSce
 		&scenarioStubBillingMonthDetailUseCase{},
 		log,
 	)
+	dashboardController := dashboardpresentation.NewController(&scenarioStubDashboardSummaryUseCase{}, log)
 
 	router := gin.New()
 	container := dig.New()
@@ -181,6 +186,7 @@ func newMailAccountConnectionScenarioEnv(t *testing.T) *mailAccountConnectionSce
 	require.NoError(t, container.Provide(func() *macpresentation.Controller { return macController }))
 	require.NoError(t, container.Provide(func() *manualpresentation.Controller { return manualController }))
 	require.NoError(t, container.Provide(func() *billingpresentation.Controller { return billingController }))
+	require.NoError(t, container.Provide(func() *dashboardpresentation.Controller { return dashboardController }))
 	_, err = v1.Router(router, container, log, scenarioAllowedOrigin)
 	require.NoError(t, err)
 
@@ -497,8 +503,13 @@ func (s *scenarioStubBillingMonthDetailUseCase) Get(ctx context.Context, query b
 	}, nil
 }
 
+func (s *scenarioStubDashboardSummaryUseCase) Get(ctx context.Context, query dashboardqueryapp.SummaryQuery) (dashboardqueryapp.SummaryResult, error) {
+	return dashboardqueryapp.SummaryResult{}, nil
+}
+
 var _ manualapp.StartUseCase = (*scenarioStubManualMailWorkflowUseCase)(nil)
 var _ manualapp.ListUseCase = (*scenarioStubManualMailWorkflowUseCase)(nil)
 var _ billingqueryapp.ListUseCaseInterface = (*scenarioStubBillingListUseCase)(nil)
 var _ billingqueryapp.MonthlyTrendUseCaseInterface = (*scenarioStubBillingMonthlyTrendUseCase)(nil)
 var _ billingqueryapp.MonthDetailUseCaseInterface = (*scenarioStubBillingMonthDetailUseCase)(nil)
+var _ dashboardqueryapp.SummaryUseCaseInterface = (*scenarioStubDashboardSummaryUseCase)(nil)


### PR DESCRIPTION
# 概要
手動実行履歴テーブルの解析結果数を集計して返却するAPIを実装

## 変更内容の要約
- 手動実行履歴テーブルの解析結果数を集計して返却するAPIを実装

## 動作確認
- [x] TODOコメントを削除しています。TODOコメントを残す場合は妥当な理由があることを説明済みです。
- [x] 動作確認を行いました。
- [x] ローカル環境で`task test`が成功しています。
- [x] CIが成功しています。

## その他
- 懸念点があれば
